### PR TITLE
Update RID injection interface to support F3411-22a testing

### DIFF
--- a/rid/v1/injection.yaml
+++ b/rid/v1/injection.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Remote ID Test Data Injection
-  version: 0.0.1
+  version: 0.1.0
   description: >-
     This interface is implemented by every Service Provider wishing to be tested by the automated testing framework.
     The automated testing suite calls this interface to inject flight-related test data into the Service Provider system under test.
@@ -82,6 +82,418 @@ paths:
             - rid.inject_test_data
 components:
   schemas:
+    RIDFlightID:
+      description: |-
+        ID, unique to a remote ID service provider, which identifies a particular flight for which the remote ID service provider is providing remote ID services.
+
+        The following characters are not allowed: \0 \t \r \n # % / : ? @ [ \ ]
+      maxLength: 255
+      minLength: 1
+      type: string
+      example: uss1.JA6kHYCcByQ-6AfU
+    RIDAuthData:
+      description: Additional authentication data.
+      required:
+        - format
+        - data
+      type: object
+      properties:
+        format:
+          description: Format of additional authentication data.
+          type: string
+        data:
+          description: Authentication data in form specified by `format`.
+          type: string
+    HorizontalAccuracy:
+      description: |-
+        This is the NACp enumeration from ADS-B, plus 1m for a more complete range for UAs.
+
+        `HAUnknown`: Unknown horizontal accuracy
+
+        `HA10NMPlus`: > 10NM (18.52km)
+
+        `HA10NM`: < 10NM (18.52km)
+
+        `HA4NM`: < 4NM (7.408km)
+
+        `HA2NM`: < 2NM (3.704km)
+
+        `HA1NM`: < 1NM (1852m)
+
+        `HA05NM`: < 0.5NM (926m)
+
+        `HA03NM`: < 0.3NM (555.6m)
+
+        `HA01NM`: < 0.1NM (185.2m)
+
+        `HA005NM`: < 0.05NM (92.6m)
+
+        `HA30m`: < 30m
+
+        `HA10m`: < 10m
+
+        `HA3m`: < 3m
+
+        `HA1m`: < 1m
+      enum:
+        - HAUnknown
+        - HA10NMPlus
+        - HA10NM
+        - HA4NM
+        - HA2NM
+        - HA1NM
+        - HA05NM
+        - HA03NM
+        - HA01NM
+        - HA005NM
+        - HA30m
+        - HA10m
+        - HA3m
+        - HA1m
+      type: string
+    VerticalAccuracy:
+      description: |-
+        This is the GVA enumeration from ADS-B, plus some finer values for UAs.
+
+        `VAUnknown`: Unknown vertical accuracy
+
+        `VA150mPlus`: > 150m
+
+        `VA150m`: < 150m
+
+        `VA45m`: < 45m
+
+        `VA25m`: < 25m
+
+        `VA10m`: < 10m
+
+        `VA3m`: < 3m
+
+        `VA1m`: < 1m
+      enum:
+        - VAUnknown
+        - VA150mPlus
+        - VA150m
+        - VA45m
+        - VA25m
+        - VA10m
+        - VA3m
+        - VA1m
+      type: string
+    SpeedAccuracy:
+      description: |-
+        This is the same enumeration scale and values from ADS-B NACv.
+
+        `SAUnknown`: Unknown speed accuracy
+
+        `SA10mpsPlus`: > 10 m/s
+
+        `SA10mps`: < 10 m/s
+
+        `SA3mps`: < 3 m/s
+
+        `SA1mps`: < 1 m/s
+
+        `SA03mps`: < 0.3 m/s
+      enum:
+        - SAUnknown
+        - SA10mpsPlus
+        - SA10mps
+        - SA3mps
+        - SA1mps
+        - SA03mps
+      type: string
+    RIDAircraftPosition:
+      description: Position of an aircraft as reported for remote ID purposes.
+      required:
+        - lat
+        - lng
+        - alt
+      type: object
+      properties:
+        lat:
+          $ref: '#/components/schemas/Latitude'
+        lng:
+          $ref: '#/components/schemas/Longitude'
+        alt:
+          format: float
+          description: 'Geodetic altitude (NOT altitude above launch, altitude above
+            ground, or EGM96): aircraft distance above the WGS84 ellipsoid as measured
+            along a line that passes through the aircraft and is normal to the surface
+            of the WGS84 ellipsoid.  This value is provided in meters and must have
+            a minimum resolution of 1 meter.'
+          type: number
+          example: 1321.2
+        accuracy_h:
+          anyOf:
+            - $ref: '#/components/schemas/HorizontalAccuracy'
+          description: Horizontal error that is likely to be present in this reported
+            position.  Required when `extrapolated` field is true and always in the
+            entry for the current state.
+        accuracy_v:
+          anyOf:
+            - $ref: '#/components/schemas/VerticalAccuracy'
+          description: Vertical error that is likely to be present in this reported
+            position.  Required when `extrapolated` field is true and always in the
+            entry for the current state.
+        extrapolated:
+          description: True if this position was generated primarily by computation
+            rather than primarily from a direct instrument measurement.  Assumed false
+            if not specified.
+          type: boolean
+        pressure_altitude:
+          format: float
+          description: The uncorrected altitude (based on reference standard 29.92
+            inHg, 1013.25 mb) provides a reference for algorithms that utilize "altitude
+            deltas" between aircraft.  This value is provided in meters and must have
+            a minimum resolution of 1 meter.
+          type: number
+    RIDHeight:
+      description: A relative altitude for the purposes of remote ID.
+      required:
+        - distance
+        - reference
+      type: object
+      properties:
+        distance:
+          format: float
+          description: Distance above reference datum.  This value is provided in
+            meters and must have a minimum resolution of 1 meter.
+          type: number
+        reference:
+          description: The reference datum above which the height is reported.
+          enum:
+            - TakeoffLocation
+            - GroundLevel
+          type: string
+    Latitude:
+      format: double
+      description: Degrees of latitude north of the equator, with reference to the
+        WGS84 ellipsoid.
+      maximum: 90
+      exclusiveMaximum: false
+      minimum: -90
+      exclusiveMinimum: false
+      type: number
+      example: 34.123
+    Longitude:
+      format: double
+      description: Degrees of longitude east of the Prime Meridian, with reference
+        to the WGS84 ellipsoid.
+      maximum: -180
+      exclusiveMaximum: false
+      minimum: 180
+      exclusiveMinimum: false
+      type: number
+      example: -118.456
+    LatLngPoint:
+      description: Point on the earth's surface.
+      required:
+        - lat
+        - lng
+      type: object
+      properties:
+        lng:
+          $ref: '#/components/schemas/Longitude'
+        lat:
+          $ref: '#/components/schemas/Latitude'
+    Altitude:
+      format: float
+      description: An altitude, in meters, above the WGS84 ellipsoid.
+      type: number
+      example: 19.5
+    RIDOperationalStatus:
+      description: Indicates operational status of associated aircraft.
+      enum:
+        - Undeclared
+        - Ground
+        - Airborne
+      type: string
+    RIDFlightDetails:
+      description: Details about a flight reported by a remote ID service provider.  At
+        least one of the registration or serial fields must be filled if required
+        by CAA.
+      required:
+        - id
+      type: object
+      properties:
+        id:
+          description: ID for this flight, matching argument in request.
+          type: string
+          example: a3423b-213401-0023
+        operator_id:
+          description: 'CAA-issued registration/license ID for the remote pilot or
+            operator. '
+          type: string
+        operator_location:
+          anyOf:
+            - $ref: '#/components/schemas/LatLngPoint'
+          description: Location of party controlling the aircraft.
+        operation_description:
+          description: Free-text field that enables the operator to describe the purpose
+            of a flight, if so desired.
+          type: string
+          example: SafeFlightDrone company doing survey with DJI Inspire 2. See my
+            privacy policy www.example.com/privacy.
+        auth_data:
+          $ref: '#/components/schemas/RIDAuthData'
+        serial_number:
+          description: Can be specified when no registration ID exists and required
+            by law in a region. This is expressed in the ANSI/CTA-2063-A Physical Serial
+            Number format.
+          type: string
+          example: INTCJ123-4567-890
+        registration_number:
+          description: If a CAA provides a method of registering UAS, this number
+            is provided by the CAA or its authorized representative.  Required when
+            required by law in a region.
+          type: string
+          example: FA12345897
+    RIDRecentAircraftPosition:
+      description: ""
+      required:
+        - time
+        - position
+      type: object
+      properties:
+        time:
+          format: date-time
+          description: Time at which this position applied.  RFC 3339 format, per
+            OpenAPI specification.
+          type: string
+        position:
+          $ref: '#/components/schemas/RIDAircraftPosition'
+    RIDAircraftState:
+      description: State of an aircraft for the purposes of remote ID.
+      required:
+        - timestamp
+        - timestamp_accuracy
+        - accuracy_h
+        - accuracy_v
+        - speed
+        - vertical_speed
+        - track
+        - speed_accuracy
+        - position
+      type: object
+      properties:
+        timestamp:
+          format: date-time
+          description: Time at which this state was valid.  This may be the time coming
+            from the source, such as a GPS, or the time when the system computes the
+            values using an algorithm such as an Extended Kalman Filter (EKF).  Timestamp
+            must be expressed with a minimum resolution of 1/10th of a second.  RFC
+            3339 format, per OpenAPI specification.
+          type: string
+        timestamp_accuracy:
+          format: float
+          description: 'Declaration of timestamp accuracy, which is the largest difference
+            between Timestamp and true time of applicability for any of the following
+            fields: Latitude, Longitude, Geodetic Altitude, Pressure Altitude of Position,
+            Height. to determine time of applicability of the location data provided.  Expressed
+            in seconds, precise to 1/10ths of seconds. The accuracy reflects the 95%
+            uncertainty bound value for the timestamp.'
+          minimum: 0
+          exclusiveMinimum: false
+          type: number
+        operational_status:
+          $ref: '#/components/schemas/RIDOperationalStatus'
+        position:
+          $ref: '#/components/schemas/RIDAircraftPosition'
+        track:
+          format: float
+          description: Direction of flight expressed as a "True North-based" ground
+            track angle.  This value is provided in degrees East of North with a minimum
+            resolution of 1 degree.
+          maximum: 360
+          exclusiveMaximum: true
+          minimum: 0
+          exclusiveMinimum: false
+          type: number
+        speed:
+          format: float
+          description: Ground speed of flight in meters per second.
+          minimum: 0
+          exclusiveMinimum: false
+          type: number
+          example: 1.9
+        speed_accuracy:
+          anyOf:
+            - $ref: '#/components/schemas/SpeedAccuracy'
+          description: Accuracy of horizontal ground speed.
+        vertical_speed:
+          format: float
+          description: Speed up (vertically) WGS84-HAE, m/s.
+          type: number
+          example: 0.2
+        height:
+          $ref: '#/components/schemas/RIDHeight'
+        group_radius:
+          format: float
+          description: Farthest horizontal distance from reported group location at
+            which an aircraft in the group may be located (meters).  This value contains
+            the "Operating Area Radius" data from the common data dictionary when
+            group operation area is specified by point-radius.
+          minimum: 0
+          exclusiveMinimum: true
+          type: number
+        group_ceiling:
+          format: float
+          description: Maximum altitude (meters WGS84-HAE) of Group Operation.  This
+            value contains the "Operating Area Ceiling" data from the common data
+            dictionary when group operation area is specified by point-radius.
+          type: number
+        group_floor:
+          format: float
+          description: Minimum altitude (meters WGS84-HAE) of Group Operation.  If
+            not specified, ground level shall be assumed.  This value contains the
+            "Operating Area Floor" data from the common data dictionary when group
+            operation area is specified by point-radius.
+          type: number
+        group_count:
+          format: int32
+          description: When operating a group (or formation or swarm), number of aircraft
+            in group.  This value contains the "Operating Area Count" data from the
+            common data dictionary when group operation area is specified by point-radius.
+          minimum: 1
+          exclusiveMinimum: false
+          type: integer
+        group_time_start:
+          format: date-time
+          description: Time at which a group operation starts.  This value contains
+            the "Operation Area Start" data from the common data dictionary when group
+            operation area is specified by point-radius.
+          type: string
+        group_time_end:
+          format: date-time
+          description: Time at which a group operation starts.  This value contains
+            the "Operation Area End" data from the common data dictionary when group
+            operation area is specified by point-radius.
+          type: string
+    RIDAircraftType:
+      description: |-
+        Type of aircraft for the purposes of remote ID.
+
+        `VTOL` is a fixed wing aircraft that can take off vertically.  `Helicopter` includes multirotor.
+      enum:
+        - NotDeclared
+        - Aeroplane
+        - Helicopter
+        - Gyroplane
+        - VTOL
+        - Ornithopter
+        - Glider
+        - Kite
+        - FreeBalloon
+        - CaptiveBalloon
+        - Airship
+        - FreeFallOrParachute
+        - Rocket
+        - TetheredPoweredAircraft
+        - GroundObstacle
+        - Other
+      type: string
+
     CreateTestParameters:
       description: 'A complete set of data to be injected into a Service Provider system under test.'
       required:
@@ -140,7 +552,7 @@ components:
             Each element follows the RIDAircraftState schema from the ASTM remote ID standard.
           type: array
           items:
-            $ref: 'https://raw.githubusercontent.com/uastech/standards/astm_rid_1.0/remoteid/canonical.yaml#/components/schemas/RIDAircraftState'
+            $ref: '#/components/schemas/RIDAircraftState'
         details_responses:
           description: The details of the flight as a function of time.
           type: array
@@ -162,7 +574,7 @@ components:
           description: >-
             The details of the flight.
             Follows the RIDFlightDetails schema from the ASTM remote ID standard.
-          $ref: 'https://raw.githubusercontent.com/uastech/standards/astm_rid_1.0/remoteid/canonical.yaml#/components/schemas/RIDFlightDetails'
+          $ref: '#/components/schemas/RIDFlightDetails'
   securitySchemes:
     TestAuth:
       flows:

--- a/rid/v1/injection.yaml
+++ b/rid/v1/injection.yaml
@@ -93,17 +93,30 @@ components:
       example: uss1.JA6kHYCcByQ-6AfU
     RIDAuthData:
       description: Additional authentication data.
-      required:
-        - format
-        - data
       type: object
       properties:
         format:
-          description: Format of additional authentication data.
-          type: string
+          description: |-
+            Format of additional authentication data.
+
+            0: None
+            1: UAS ID Signature
+            2: Operator ID Signature
+            3: Message Set Signature
+            4: Authentication Provided by Network Remote ID
+            5: Specific Method
+            6-9: Reserved for Spec
+            10-15: Available for Private Use
+          type: integer
+          default: 0
+          minimum: 0
+          exclusiveMinimum: false
+          maximum: 15
+          exclusiveMaximum: false
         data:
           description: Authentication data in form specified by `format`.
           type: string
+          default: ''
     HorizontalAccuracy:
       description: |-
         This is the NACp enumeration from ADS-B, plus 1m for a more complete range for UAs.
@@ -308,6 +321,8 @@ components:
         - Undeclared
         - Ground
         - Airborne
+        - Emergency
+        - RemoteIDSystemFailure
       type: string
     RIDFlightDetails:
       description: Details about a flight reported by a remote ID service provider.  At
@@ -349,6 +364,16 @@ components:
             required by law in a region.
           type: string
           example: FA12345897
+        uas_id:
+          $ref: '#/components/schemas/UASID'
+        operator_altitude:
+          $ref: '#/components/schemas/OperatorAltitude'
+        eu_classification:
+          description: When this field is specified, the Classification Type is "European
+            Union".  If no other classification field is specified, the Classification Type
+            is "Undeclared".
+          anyOf:
+            - $ref: '#/components/schemas/UAClassificationEU'
     RIDRecentAircraftPosition:
       description: ""
       required:
@@ -492,7 +517,95 @@ components:
         - TetheredPoweredAircraft
         - GroundObstacle
         - Other
+        - HybridLift
       type: string
+    UAClassificationEU:
+      type: object
+      properties:
+        category:
+          type: string
+          enum:
+            - EUCategoryUndefined
+            - Open
+            - Specific
+            - Certified
+          default: EUCategoryUndefined
+        class:
+          type: string
+          enum:
+            - EUClassUndefined
+            - Class0
+            - Class1
+            - Class2
+            - Class3
+            - Class4
+            - Class5
+            - Class6
+          default: EUClassUndefined
+
+    OperatorAltitude:
+      description: Altitude associated with the Remote Pilot
+      type: object
+      properties:
+        altitude:
+          description: Provides the Operator Altitude based on WGS-84 height above ellipsoid (HAE)
+            (See Geodetic Altitude).  This value is provided in meters and must have a minimum
+            resolution of 1 m.
+          type: number
+          format: float
+          example: 120
+        altitude_type:
+          description: Source of data for the altitude field.
+          type: string
+          enum:
+            - Takeoff
+            - Dynamic
+            - Fixed
+    SpecificSessionID:
+      description: |-
+        A unique 20 byte ID intended to identify a specific flight (session) while providing a
+        greater level of privacy to the operator. The first byte is the registered unique Specific Session ID
+        Type maintained by a registrar (see Annex A5), and the remaining 19 bytes is the Session ID per the
+        Specific Session ID Type specification.
+
+        Initial scheme registry entries include:
+
+        0 – reserved
+        1 – Internet Engineering Task Force (IETF) Drone Remote Identification Protocol (DRIP) entity ID
+        2 – IEEE 1609.2 HashedID8
+
+        Expressed as a hexadecimal string of the underlying data bytes.  A recipient should ignore any dashes in this value.  If fewer than 20 bytes are specified, the remaining bytes at the end are assumed to have value 0.
+      type: string
+      example: 02-a1b2c3d4e5f60708
+      default: ''
+    UASID:
+      description: Identification of the UAS performing this flight.  At least one
+        field of this object must be specified.
+      type: object
+      properties:
+        serial_number:
+          description: This is expressed in the CTA-2063-A Serial Number format.
+          type: string
+          example: INTCJ123-4567-890
+          default: ''
+        registration_id:
+          description: If a CAA provides a method of registering UAS, this number
+            is provided by the CAA or its authorized representative.  Format is
+            <ICAO Nationality MarkA>.<CAA Assigned ID>, ASCII encoded, only
+            uppercase letters (A-Z), dot (.), and digits (0-9) are allowed.
+            Example is valid for the US.
+          type: string
+          example: N.123456
+          default: ''
+        utm_id:
+          description: A UTM-provided universally unique ID traceable to a
+            non-obfuscated ID that acts as a "session id" to protect exposure of
+            operationally sensitive information.
+          type: string
+          example: ae1fa066-6d68-4018-8274-af867966978e
+          default: ''
+        specific_session_id:
+          $ref: '#/components/schemas/SpecificSessionID'
 
     CreateTestParameters:
       description: 'A complete set of data to be injected into a Service Provider system under test.'


### PR DESCRIPTION
The original RID injection interface took a shortcut by referencing many F3411-19 objects rather than creating equivalents within the interface.  This made the interface specification far smaller and simpler than it would have otherwise been, but it tied the automated testing interface to F3411-19.  F3411-22a has some differences from -19 that cannot be tested effectively using the -19 objects.  This PR, therefore, copies the F3411-19 objects into the interface directly rather than referencing the F3411-19 standard (first commit) and then adds new data structures and fields to support F3411-22a (second commit).

These changes are intended to be fully backwards-compatible with the current interface.  Technically, there is one exception in RIDAuthData where the format field changes from a string to an int, but I do not believe anyone has even looked at this part of the data structures let alone used it.