### PR TITLE
[scd] Add NotSupported option and coalesce Rejected + ConflictWithFlight

### DIFF
--- a/scd/v1/scd.yaml
+++ b/scd/v1/scd.yaml
@@ -1,10 +1,10 @@
 openapi: 3.0.2
 info:
   title: Strategic Coordination Test Data Injection
-  version: 0.0.1
+  version: 0.1.0
   description: >-
-    This interface is implemented by every USS wishing to be tested by the automated testing framework.
-    The automated testing suite calls this interface to inject test data into the USS system under test.
+    This interface is implemented by every USS wishing to enable the automated testing framework to interact with the
+    USS as a user planning flights.  This interaction capability is required by some automated tests.
 
 components:
   securitySchemes:
@@ -433,21 +433,24 @@ components:
       properties:
         result:
           description: >-
-            The result of the flight submission
+            The result of the flight submission.
+            If any option other than `Planned` or `ReadyToFly` is specified, the `notes` field should be populated with the reason for the unsuccessful outcome.
 
               - `Planned`: The flight submission data was valid and the flight was successfully processed by the USS and is now authorized.
 
               - `ReadyToFly`: The flight is ready for the operator to begin flying.
 
-              - `Rejected`: The flight submission data provided was invalid and/or could not be used to attempt to authorize the flight.
+              - `Rejected`: The flight submission data provided was invalid and/or could not be used to attempt to authorize the flight.  The reason for rejection may include a disallowed conflict with another flight.
 
-              - `ConflictWithFlight`: The flight submission data was valid, but the flight could not be authorized because of a disallowed conflict with another flight.
+              - `ConflictWithFlight`: (deprecated; use Rejected instead) The flight submission data was valid, but the flight could not be authorized because of a disallowed conflict with another flight.
 
               - `Failed`: The USS was not able to successfully authorize the flight due to a problem with the USS or a downstream system
+            
+              - `NotSupported`: The USS does not support the attempted interaction.  For instance, if the request specified a high-priority flight and the USS does not support management of high-priority flights.
 
           type: string
-          enum: [Planned, ReadyToFly, Rejected, ConflictWithFlight, Failed]
-          example: ConflictWithFlight
+          enum: [Planned, ReadyToFly, Rejected, ConflictWithFlight, Failed, NotSupported]
+          example: Planned
         notes:
           description: >-
             Human-readable explanation of the observed result.  This explanation


### PR DESCRIPTION
Currently, the scd interface for requesting USS flight planning operations has a "capabilities" endpoint that allows a USS to indicate what capabilities it supports, and then uss_qualifier chooses to skip test components that need unsupported capabilities.  This is somewhat awkward as all variations of all optional capabilities for all tests involving this interface would need to be added to the capabilities result data structure to support this paradigm.

Instead, this PR adds a "NotSupported" option when a requested flight interaction is not supported.  With that possibility, uss_qualifier can simply stop a test scenario if one of the participants is discovered to be unable to support a required action given the full details of that action.  This opens up the number of USS behaviors that can be supported -- for instance, if a USS can support high-priority operations, but only when they originate from specific users, the old/current paradigm does not support that behavior, but the new paradigm would.

This is a backwards-compatible change because a new enum option is added so all previous responses will still validate.  After this behavior is incorporated/supported by uss_qualifier and USSs, the capabilities endpoint can be entirely removed from this API.

As a second change, the ConflictWithFlight option is marked as deprecated as the distinction between Rejected and ConflictWithFlight is not particularly useful, and it does lead to some difficulties (e.g., if a request both contains invalid data and conflicts with another flight, which result should be returned?).  The tests should be constructed to evoke all rejection reasons of interest separately, so having the USS attempt to indicate the "root cause" of a rejection is not necessary.  It will become increasingly important to avoid attempting to differentiate rejection reasons as this API is used for flight planning interactions beyond U-space.

API changes have large, long-lasting impacts, so please provide robust feedback where appropriate :)