### PR TITLE
Add geospatial map interface and deprecate geo-awareness interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ This repository houses the interfaces a USS/USSP must implement in order to be t
 
 ## Interfaces
 
-* [Geo-awareness](geo-awareness/README.md)
+* [Geo-awareness](geo-awareness/README.md) (DEPRECATED; see [Geospatial map](geospatial_map) instead)
   * [v1 YAML](geo-awareness/v1/geo-awareness.yaml)
+* [Geospatial map](geospatial_map/README.md)
+  * [v1 YAML](geospatial_map/v1/geospatial_map.yaml) 
 * [Remote ID](rid/README.md)
   * Injection (for NetRID Service Providers)
     * [v1 YAML](rid/v1/injection.yaml)

--- a/geo-awareness/README.md
+++ b/geo-awareness/README.md
@@ -1,5 +1,10 @@
 # Geo-Awareness automated testing interface
 
+---
+Note: This interface is DEPRECATED and will be REMOVED.  The replacement interface is the [geospatial map interface](../geospatial_map).
+
+---
+
 This folder contains the [USSP interface for Geo-Awareness automated testing](v1/geo-awareness.yaml).
 
 ## Overview

--- a/geospatial_map/README.md
+++ b/geospatial_map/README.md
@@ -1,0 +1,26 @@
+# Geospatial map automated testing interface
+
+This folder contains the [USSP interface for geospatial map automated testing](v1/geospatial_map.yaml).
+
+## Overview
+
+This interface is designed to support the following scenario:
+> If I (the test director, acting like a normal client operator) were to "view" your (the USSP under test) geospatial map at this specific point, would you (the USSP under test) indicate that there are any applicable geospatial features on the map at that point?
+
+It also supports other actions likely associated with tests involving geospatial maps, such as the test director requesting and ensuring that the USSP under test has loaded a particular geospatial dataset.
+
+This interface supports testing of the U-space Geo-Awareness service and other similar services.
+
+It has been designed to impose minimal additional requirements on USSP implementations.
+[See discussion for details](https://github.com/interuss/dss/pull/809#discussion_r982930704)
+
+## Viewing locally
+To view a description of this interface locally, from this folder:
+
+```shell script
+docker run -it --rm -p 8080:8080 \
+  -v $(pwd)/:/usr/share/nginx/html/api/ \
+  -e PORT=8080 -e SPEC_URL=./api/v1/geospatial_map.yaml redocly/redoc
+```
+
+...then visit [http://localhost:8080/](http://localhost:8080/) in a browser.

--- a/geospatial_map/v1/astm_f3548_21.yaml
+++ b/geospatial_map/v1/astm_f3548_21.yaml
@@ -62,12 +62,11 @@ components:
         reference:
           description: >-
             A code indicating the reference for a vertical distance. See AIXM
-            5.1 and FIXM 4.2.0. Currently, UTM only allows WGS84 with no
-            immediate plans to allow other options. FIXM and AIXM allow for
-            'SFC' which is equivalent to AGL.
+            5.1 and FIXM 4.2.0.
           type: string
           enum:
             - W84
+            - SFC
         units:
           description: >-
             The reference quantities used to express the value of altitude. See

--- a/geospatial_map/v1/astm_f3548_21.yaml
+++ b/geospatial_map/v1/astm_f3548_21.yaml
@@ -1,0 +1,182 @@
+openapi: 3.0.2
+info:
+  title: Definitions used in geospatial map interface designed to align with data structures from ASTM F3548-21
+components:
+  schemas:
+    Time:
+      required:
+        - value
+        - format
+      type: object
+      properties:
+        value:
+          type: string
+          description: >-
+            RFC3339-formatted time/date string.  The time zone must be 'Z'.
+          format: date-time
+          example: '1985-04-12T23:20:50.52Z'
+        format:
+          type: string
+          enum:
+            - RFC3339
+    Radius:
+      required:
+        - value
+        - units
+      type: object
+      properties:
+        value:
+          format: float
+          description: >-
+            Distance from the centerpoint of a circular area, along the WGS84
+            ellipsoid.
+          type: number
+          minimum: 0
+          exclusiveMinimum: true
+          example: 300.183
+        units:
+          type: string
+          description: >-
+            FIXM-compatible units.  Only meters ("M") are acceptable for UTM.
+          enum:
+            - M
+    Altitude:
+      type: object
+      required:
+        - value
+        - reference
+        - units
+      properties:
+        value:
+          description: >-
+            The numeric value of the altitude. Note that min and max values are
+            added as a sanity check. As use cases evolve and more options are
+            made available in terms of units of measure or reference systems,
+            these bounds may be re-evaluated.
+          type: number
+          format: double
+          minimum: -8000
+          exclusiveMinimum: false
+          maximum: 100000
+          exclusiveMaximum: false
+        reference:
+          description: >-
+            A code indicating the reference for a vertical distance. See AIXM
+            5.1 and FIXM 4.2.0. Currently, UTM only allows WGS84 with no
+            immediate plans to allow other options. FIXM and AIXM allow for
+            'SFC' which is equivalent to AGL.
+          type: string
+          enum:
+            - W84
+        units:
+          description: >-
+            The reference quantities used to express the value of altitude. See
+            FIXM 4.2. Currently, UTM only allows meters with no immediate plans
+            to allow other options.
+          type: string
+          enum:
+            - M
+    Latitude:
+      description: >-
+        Degrees of latitude north of the equator, with reference to the WGS84
+        ellipsoid.
+      maximum: 90
+      exclusiveMaximum: false
+      minimum: -90
+      exclusiveMinimum: false
+      type: number
+      format: double
+      example: 34.123
+    Longitude:
+      description: >-
+        Degrees of longitude east of the Prime Meridian, with reference to the
+        WGS84 ellipsoid.
+      minimum: -180
+      exclusiveMaximum: false
+      maximum: 180
+      exclusiveMinimum: false
+      type: number
+      format: double
+      example: -118.456
+    Polygon:
+      description: >-
+        An enclosed area on the earth. The bounding edges of this polygon are
+        defined to be the shortest paths between connected vertices.  This
+        means, for instance, that the edge between two points both defined at a
+        particular latitude is not generally contained at that latitude. The
+        winding order must be interpreted as the order which produces the
+        smaller area. The path between two vertices is defined to be the
+        shortest possible path between those vertices. Edges may not cross.
+        Vertices may not be duplicated.  In particular, the final polygon vertex
+        must not be identical to the first vertex.
+      required:
+        - vertices
+      type: object
+      properties:
+        vertices:
+          minItems: 3
+          type: array
+          items:
+            $ref: '#/components/schemas/LatLngPoint'
+    LatLngPoint:
+      description: Point on the earth's surface.
+      required:
+        - lat
+        - lng
+      type: object
+      properties:
+        lng:
+          $ref: '#/components/schemas/Longitude'
+        lat:
+          $ref: '#/components/schemas/Latitude'
+    Circle:
+      description: A circular area on the surface of the earth.
+      type: object
+      properties:
+        center:
+          $ref: '#/components/schemas/LatLngPoint'
+        radius:
+          $ref: '#/components/schemas/Radius'
+    Volume3D:
+      description: >-
+        A three-dimensional geographic volume consisting of a
+        vertically-extruded shape. Exactly one outline must be specified.
+      type: object
+      properties:
+        outline_circle:
+          anyOf:
+            - $ref: '#/components/schemas/Circle'
+          description: A circular geographic shape on the surface of the earth.
+        outline_polygon:
+          anyOf:
+            - $ref: '#/components/schemas/Polygon'
+          description: >-
+            A polygonal geographic shape on the surface of the earth.
+        altitude_lower:
+          description: >-
+            Minimum bounding altitude of this volume. Must be less than
+            altitude_upper, if specified.
+          anyOf:
+            - $ref: '#/components/schemas/Altitude'
+        altitude_upper:
+          description: >-
+            Maximum bounding altitude of this volume. Must be greater than
+            altitude_lower, if specified.
+          anyOf:
+            - $ref: '#/components/schemas/Altitude'
+    Volume4D:
+      description: Contiguous block of geographic spacetime.
+      required:
+        - volume
+      type: object
+      properties:
+        volume:
+          $ref: '#/components/schemas/Volume3D'
+        time_start:
+          description: Beginning time of this volume. Must be before time_end.
+          anyOf:
+            - $ref: '#/components/schemas/Time'
+        time_end:
+          description: End time of this volume. Must be after time_start.
+          anyOf:
+            - $ref: '#/components/schemas/Time'

--- a/geospatial_map/v1/astm_f3548_21.yaml
+++ b/geospatial_map/v1/astm_f3548_21.yaml
@@ -70,11 +70,11 @@ components:
         units:
           description: >-
             The reference quantities used to express the value of altitude. See
-            FIXM 4.2. Currently, UTM only allows meters with no immediate plans
-            to allow other options.
+            FIXM 4.2.
           type: string
           enum:
             - M
+            - FT
     Latitude:
       description: >-
         Degrees of latitude north of the equator, with reference to the WGS84

--- a/geospatial_map/v1/ed269.yaml
+++ b/geospatial_map/v1/ed269.yaml
@@ -3,18 +3,6 @@ info:
   title: Definitions used in geospatial map interface designed to align with data structures from ED-269
 components:
   schemas:
-    UomDimensions:
-      type: string
-      enum:
-        - M
-        - FT
-
-    VerticalReferenceType:
-      type: string
-      enum:
-        - AGL
-        - AMSL
-
     USpaceClass:
       type: string
       maxLength: 100

--- a/geospatial_map/v1/ed269.yaml
+++ b/geospatial_map/v1/ed269.yaml
@@ -1,0 +1,28 @@
+openapi: 3.0.2
+info:
+  title: Definitions used in geospatial map interface designed to align with data structures from ED-269
+components:
+  schemas:
+    UomDimensions:
+      type: string
+      enum:
+        - M
+        - FT
+
+    VerticalReferenceType:
+      type: string
+      enum:
+        - AGL
+        - AMSL
+
+    USpaceClass:
+      type: string
+      maxLength: 100
+
+    Restriction:
+      type: string
+      enum:
+        - PROHIBITED
+        - REQ_AUTHORISATION
+        - CONDITIONAL
+        - NO_RESTRICTION

--- a/geospatial_map/v1/geospatial_map.yaml
+++ b/geospatial_map/v1/geospatial_map.yaml
@@ -101,12 +101,18 @@ components:
           enum: [ED-269]
           example: ED-269
 
-    GeospatialDataSourceResponse:
+    GeospatialDataSourceStatus:
       type: object
       required:
-        - result
+        - id
+        - status
       properties:
-        result:
+        id:
+          description: >-
+            ID of this geospatial data source
+          anyOf:
+            - $ref: '#/components/schemas/UUIDv4Format'
+        status:
           description: >-
             The status of the Geospatial source and the handling of its data by the USS.
 
@@ -118,11 +124,11 @@ components:
             
             - `Deactivated`: the geospatial dataset has been deactivated (the USS may instead return 404 as well).
 
-            - `Unsupported`: the USS cannot process the dataset type specified.
+            - `Unsupported`: the USS cannot process the dataset type specified, or some valid feature within the dataset. The message field is required in this case.
 
-            - `Rejected`: the geospatial data source was rejected because it is invalid.
+            - `Rejected`: the geospatial data source was rejected because it failed content validation or was otherwise unsuitable to use. The message field is required in this case.
 
-            - `Error`: the geospatial data activation or deactivation failed. The message field is required in this case.
+            - `Error`: the geospatial data activation or deactivation failed for a reason not covered by one of the previous options. The message field is required in this case.
           type: string
           enum: [Activating, Ready, Deactivating, Deactivated, Unsupported, Rejected, Error]
           example: Ready
@@ -132,31 +138,37 @@ components:
           example: |-
             Unable to download the dataset https://caa.example.com/geozones.json. Connection refused.
 
+    GeospatialDataSourceResponse:
+      type: object
+      required:
+        - data_source
+      properties:
+        data_source:
+          $ref: '#/components/schemas/GeospatialDataSourceStatus'
+
+    ListGeospatialDataSourcesResponse:
+      type: object
+      properties:
+        data_sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/GeospatialDataSourceStatus'
+
     Position:
       type: object
       required:
-        - uomDimensions
-        - verticalReferenceType
+        - location
       properties:
-        uomDimensions:
-          $ref: './ed269.yaml#/components/schemas/UomDimensions'
-        verticalReferenceType:
-          $ref: './ed269.yaml#/components/schemas/VerticalReferenceType'
-        height:
+        altitude:
           description: >-
-            Height above vertical reference datum indicated in `verticalReferenceType`, in units of `uomDimensions`.
-          type: number
-          default: 0
-        longitude:
+            Position's height above a vertical reference datum.
+          anyOf:
+            - $ref: './astm_f3548_21.yaml#/components/schemas/Altitude'
+        location:
           description: >-
-            Longitude, degrees east of prime meridian.
-          type: number
-          default: 0
-        latitude:
-          description: >-
-            Latitude, degrees north of the equator.
-          type: number
-          default: 0
+            Position's horizontal (along Earth's surface) location.
+          anyOf:
+            - $ref: './astm_f3548_21.yaml#/components/schemas/LatLngPoint'
 
     GeospatialMapQueryRequest:
       type: object
@@ -173,7 +185,7 @@ components:
       required:
         - filterSets
       properties:
-        filterSets:
+        filter_sets:
           description: >-
             Select geospatial features which match any of the specified filter sets.
           type: array
@@ -247,12 +259,12 @@ components:
         Filter criteria for the selection of Geozones according to ED-269 characteristics.
       type: object
       properties:
-        uSpaceClass:
+        u_space_class:
           description: >-
-            If specified, only select Geozones which are of the specified `uSpaceClass`.
+            If specified, only select Geozones which are of the specified `u_space_class`.
           anyOf:
             - $ref: './ed269.yaml#/components/schemas/USpaceClass'
-        acceptableRestrictions:
+        acceptable_restrictions:
           description: >-
             If specified and non-empty, only select Geozones which are one of the specified restriction types.
           type: array
@@ -275,15 +287,18 @@ components:
       required:
         - featuresSelectionOutcome
       properties:
-        featuresSelectionOutcome:
+        features_selection_outcome:
           type: string
           description: >-
             Indication of whether one or more applicable geospatial features were selected according to the selection criteria of the corresponding check.
             
-            * Present: One or more applicable geospatial features were selected.
-            * Absent: No applicable geospatial features were selected.
-            * UnsupportedFilter: Applicable geospatial features could not be selected because one or more filter criteria are not supported by the USS.  If this value is specified, `message` must be populated.
-            * Error: An error or condition not enumerated above occurred.  If this value is specified, `message` must be populated.
+            - `Present`: One or more applicable geospatial features were selected.
+            
+            - `Absent`: No applicable geospatial features were selected.
+            
+            - `UnsupportedFilter`: Applicable geospatial features could not be selected because one or more filter criteria are not supported by the USS.  If this value is specified, `message` must be populated.
+            
+            - `Error`: An error or condition not enumerated above occurred.  If this value is specified, `message` must be populated.
           enum:
             - Present
             - Absent
@@ -310,7 +325,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/StatusResponse'
           description: >-
-            The USS automated testing interface is available and its status was retrieved successfully.
+            The USS's implementation of this automated testing interface is available and its status was retrieved successfully.
         '401':
           description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
         '403':
@@ -319,6 +334,27 @@ paths:
           description: The USS automated testing interface is not available.
       summary: Status of the USS automated testing interface
       description: Get the status of the USS automated testing interface.
+
+  /geospatial_data_sources:
+    get:
+      security:
+        - TestAuthority:
+            - interuss.geospatial_map.direct_automated_test
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ListGeospatialDataSourcesResponse'
+          description: >-
+            The USS's geospatial data sources loaded through this interface were retrieved successfully.
+        '401':
+          description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+        '403':
+          description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+      operationId: ListGeospatialDataSources
+      summary: List geospatial data sources
+      description: Lists the geospatial data sources loaded by the USS at the request of the test director.
 
   /geospatial_data_sources/{geospatial_data_source_id}:
     parameters:
@@ -350,6 +386,8 @@ paths:
           description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
         '403':
           description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+        '409':
+          description: A request with this ID has already been made to load a different data source.
       operationId: PutGeospatialDataSource
       summary: Import and activate a geospatial data source
       description: Instructs the USS to import and activate the geospatial data from the specified source.

--- a/geospatial_map/v1/geospatial_map.yaml
+++ b/geospatial_map/v1/geospatial_map.yaml
@@ -63,11 +63,21 @@ components:
           type: string
           enum: [Starting, Ready]
           example: Ready
-        version:
+        system_version:
           description: |-
             Arbitrary string representing the version of the USS system to be tested.
           type: string
           example: v0.0.1-445ad3
+        api_name:
+          description: |-
+            Indication of the API implemented at this URL.  Must be "Geospatial Map Provider Automated Testing Interface".
+          type: string
+          example: Geospatial Map Provider Automated Testing Interface
+        api_version:
+          description: |-
+            Indication of the API version implemented at this URL.  Must be "v0.1.0" when implementing this version of the API.
+          type: string
+          example: v0.1.0
 
     CreateGeospatialDataSourceRequest:
       type: object
@@ -122,38 +132,6 @@ components:
           example: |-
             Unable to download the dataset https://caa.example.com/geozones.json. Connection refused.
 
-    #######################################################################
-    #################### Start of ED-269 definitions    ###################
-    #######################################################################
-
-    UomDimensions:
-      type: string
-      enum:
-        - M
-        - FT
-
-    VerticalReferenceType:
-      type: string
-      enum:
-        - AGL
-        - AMSL
-
-    USpaceClass:
-      type: string
-      maxLength: 100
-
-    Restriction:
-      type: string
-      enum:
-        - PROHIBITED
-        - REQ_AUTHORISATION
-        - CONDITIONAL
-        - NO_RESTRICTION
-
-    #######################################################################
-    #################### END of ED-269 definitions    #####################
-    #######################################################################
-
     Position:
       type: object
       required:
@@ -161,9 +139,9 @@ components:
         - verticalReferenceType
       properties:
         uomDimensions:
-          $ref: '#/components/schemas/UomDimensions'
+          $ref: './ed269.yaml#/components/schemas/UomDimensions'
         verticalReferenceType:
-          $ref: '#/components/schemas/VerticalReferenceType'
+          $ref: './ed269.yaml#/components/schemas/VerticalReferenceType'
         height:
           description: >-
             Height above vertical reference datum indicated in `verticalReferenceType`, in units of `uomDimensions`.
@@ -212,6 +190,13 @@ components:
             If specified, only select geospatial features encompassing this position.
           anyOf:
             - $ref: '#/components/schemas/Position'
+        volumes4d:
+          description: >-
+            If specified, only select geospatial features at least partially intersecting one or more of these volumes.
+          type:
+            array
+          items:
+            $ref: './astm_f3548_21.yaml#/components/schemas/Volume4D'
         after:
           description: >-
             If specified, only select geospatial features which encompass at least some times at or after this time.
@@ -222,6 +207,38 @@ components:
             If specified, only select geospatial features which encompass at least some times at or before this time.
           type: string
           format: date-time
+        restriction_source:
+          description: >-
+            If specified, only select geospatial features originating from the named source.  The acceptable values for
+            this field will be established by the test designers and will generally be used to limit responses to only
+            the intended datasets under test even when the USS may have more additional geospatial features from other
+            sources that may otherwise be relevant.
+          type: string
+          example: FAA_LAANC
+        operation_rule_set:
+          description: >-
+            If specified, only select geospatial features that would be relevant when planning an operation under the
+            specified rule set.  The acceptable values for this field will be established by the test designers and will
+            generally correspond to sets of rules under which the system under test plans operations.
+          type: string
+          example: Part107
+        resulting_operational_impact:
+          description: >-
+            If specified, only select geospatial features that would cause the specified outcome if a user attempted to
+            plan a flight applicable to all the other criteria in this filter set.
+            
+            'Block': The geospatial feature would cause rejection of that flight (the USS would decline to plan the
+              flight).
+            
+            'Advise': The geospatial feature would cause the USS to accompany a successful flight plan (if the flight
+              was successfully planned) with an advisory or condition provided to the operator.
+            
+            'BlockOrAdvise': The geospatial feature would cause one of 'Block' or 'Advise' to be be true.
+          type: string
+          enum:
+            - Block
+            - Advise
+            - BlockOrAdvise
         ed269:
           $ref: '#/components/schemas/ED269Filters'
 
@@ -234,13 +251,13 @@ components:
           description: >-
             If specified, only select Geozones which are of the specified `uSpaceClass`.
           anyOf:
-            - $ref: '#/components/schemas/USpaceClass'
+            - $ref: './ed269.yaml#/components/schemas/USpaceClass'
         acceptableRestrictions:
           description: >-
             If specified and non-empty, only select Geozones which are one of the specified restriction types.
           type: array
           items:
-            $ref: '#/components/schemas/Restriction'
+            $ref: './ed269.yaml#/components/schemas/Restriction'
 
     GeospatialMapQueryReply:
       type: object

--- a/geospatial_map/v1/geospatial_map.yaml
+++ b/geospatial_map/v1/geospatial_map.yaml
@@ -1,0 +1,407 @@
+openapi: 3.0.2
+info:
+  title: Geospatial Map Provider Automated Testing Interface
+  version: 0.1.0
+  license:
+    name: Apache License v2.0
+    url: https://github.com/interuss/automated_testing_interfaces/blob/main/LICENSE.md
+  description: >-
+    This interface is implemented by a USS to provide uss_qualifier (and perhaps other similar clients) with the
+    capability to pretend to be a user interacting with the USS's geospatial map representation for the purpose of
+    evaluating potential flight plans.
+    
+    This interface is used by InterUSS's geospatial feature comprehension tests, so every USS wishing to be tested by
+    those tests must implement this interface.
+    
+    The automated testing suite may call this interface to first load test data into the USS system under test, and then
+    will perform virtual queries on the USS's geospatial map to evaluate its processing and interpretation of the
+    relevant geospatial data.
+
+servers:
+  - url: https://uss.example.com/geospatial_map
+
+components:
+  securitySchemes:
+    TestAuthority:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://auth.example.com/oauth/token
+          scopes:
+            interuss.geospatial_map.direct_automated_test: |-
+              Client may determine the test-readiness of the USS and instruct the USS to load geospatial data from
+              specified data sources (acting as a test director).
+            interuss.geospatial_map.query: |-
+              Client may read information from the USS's geospatial map (acting as a user of the USS's geospatial map).
+      description: |-
+        Authorization from, or on behalf of, an authorization authority, augmenting standard Geo-Awareness authorization for the purpose of automated testing.
+
+  schemas:
+    UUIDv4Format:
+      description: >-
+        String whose format matches a version-4 UUID according to RFC 4122.
+      maxLength: 36
+      minLength: 36
+      type: string
+      format: uuid
+      pattern: >-
+        ^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$
+      example: 03e5572a-f733-49af-bc14-8a18bd53ee39
+
+    StatusResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          description: >-
+            The status of the USS automated testing interface.
+
+            - `Starting`: the USS is starting and the automated test driver should wait before sending requests.
+
+            - `Ready`: the USS is ready to receive test requests.
+          type: string
+          enum: [Starting, Ready]
+          example: Ready
+        version:
+          description: |-
+            Arbitrary string representing the version of the USS system to be tested.
+          type: string
+          example: v0.0.1-445ad3
+
+    CreateGeospatialDataSourceRequest:
+      type: object
+      properties:
+        https_source:
+          $ref: '#/components/schemas/GeospatialHttpsSource'
+
+    GeospatialHttpsSource:
+      type: object
+      required:
+        - url
+      properties:
+        url:
+          type: string
+          format: url
+          description: The URL at which the Geospatial data shall be downloaded from.
+          example: https://caa.example.com/geozones.json
+        format:
+          type: string
+          description: The format of the response expected from the source.
+          enum: [ED-269]
+          example: ED-269
+
+    GeospatialDataSourceResponse:
+      type: object
+      required:
+        - result
+      properties:
+        result:
+          description: >-
+            The status of the Geospatial source and the handling of its data by the USS.
+
+            - `Activating`: the USS is processing the request and is currently activating the geospatial data.
+
+            - `Ready`: the geospatial data has been successfully activated and the USS is ready to receive test requests.
+
+            - `Deactivating`: the geospatial dataset is being deactivated.
+            
+            - `Deactivated`: the geospatial dataset has been deactivated (the USS may instead return 404 as well).
+
+            - `Unsupported`: the USS cannot process the dataset type specified.
+
+            - `Rejected`: the geospatial data source was rejected because it is invalid.
+
+            - `Error`: the geospatial data activation or deactivation failed. The message field is required in this case.
+          type: string
+          enum: [Activating, Ready, Deactivating, Deactivated, Unsupported, Rejected, Error]
+          example: Ready
+        message:
+          description: Human-readable explanation of the result for debugging purpose only. This field is required when the result value is `Error`.
+          type: string
+          example: |-
+            Unable to download the dataset https://caa.example.com/geozones.json. Connection refused.
+
+    #######################################################################
+    #################### Start of ED-269 definitions    ###################
+    #######################################################################
+
+    UomDimensions:
+      type: string
+      enum:
+        - M
+        - FT
+
+    VerticalReferenceType:
+      type: string
+      enum:
+        - AGL
+        - AMSL
+
+    USpaceClass:
+      type: string
+      maxLength: 100
+
+    Restriction:
+      type: string
+      enum:
+        - PROHIBITED
+        - REQ_AUTHORISATION
+        - CONDITIONAL
+        - NO_RESTRICTION
+
+    #######################################################################
+    #################### END of ED-269 definitions    #####################
+    #######################################################################
+
+    Position:
+      type: object
+      required:
+        - uomDimensions
+        - verticalReferenceType
+      properties:
+        uomDimensions:
+          $ref: '#/components/schemas/UomDimensions'
+        verticalReferenceType:
+          $ref: '#/components/schemas/VerticalReferenceType'
+        height:
+          description: >-
+            Height above vertical reference datum indicated in `verticalReferenceType`, in units of `uomDimensions`.
+          type: number
+          default: 0
+        longitude:
+          description: >-
+            Longitude, degrees east of prime meridian.
+          type: number
+          default: 0
+        latitude:
+          description: >-
+            Latitude, degrees north of the equator.
+          type: number
+          default: 0
+
+    GeospatialMapQueryRequest:
+      type: object
+      required:
+        - checks
+      properties:
+        checks:
+          type: array
+          items:
+            $ref: '#/components/schemas/GeospatialMapCheck'
+
+    GeospatialMapCheck:
+      type: object
+      required:
+        - filterSets
+      properties:
+        filterSets:
+          description: >-
+            Select geospatial features which match any of the specified filter sets.
+          type: array
+          items:
+            $ref: '#/components/schemas/GeospatialFeatureFilterSet'
+
+    GeospatialFeatureFilterSet:
+      description: >-
+        Set of filters to select only a subset of geospatial features.  Only geospatial features which are applicable to all specified filters within this filter set should be selected.
+      type: object
+      properties:
+        position:
+          description: >-
+            If specified, only select geospatial features encompassing this position.
+          anyOf:
+            - $ref: '#/components/schemas/Position'
+        after:
+          description: >-
+            If specified, only select geospatial features which encompass at least some times at or after this time.
+          type: string
+          format: date-time
+        before:
+          description: >-
+            If specified, only select geospatial features which encompass at least some times at or before this time.
+          type: string
+          format: date-time
+        ed269:
+          $ref: '#/components/schemas/ED269Filters'
+
+    ED269Filters:
+      description: >-
+        Filter criteria for the selection of Geozones according to ED-269 characteristics.
+      type: object
+      properties:
+        uSpaceClass:
+          description: >-
+            If specified, only select Geozones which are of the specified `uSpaceClass`.
+          anyOf:
+            - $ref: '#/components/schemas/USpaceClass'
+        acceptableRestrictions:
+          description: >-
+            If specified and non-empty, only select Geozones which are one of the specified restriction types.
+          type: array
+          items:
+            $ref: '#/components/schemas/Restriction'
+
+    GeospatialMapQueryReply:
+      type: object
+      properties:
+        results:
+          description: >-
+            Responses to each of the `checks` in the request.  The number of entries in this array should match the number of entries in the `checks` field of the request.
+          type: array
+          items:
+            $ref: '#/components/schemas/GeospatialMapCheckResult'
+          default: []
+
+    GeospatialMapCheckResult:
+      type: object
+      required:
+        - featuresSelectionOutcome
+      properties:
+        featuresSelectionOutcome:
+          type: string
+          description: >-
+            Indication of whether one or more applicable geospatial features were selected according to the selection criteria of the corresponding check.
+            
+            * Present: One or more applicable geospatial features were selected.
+            * Absent: No applicable geospatial features were selected.
+            * UnsupportedFilter: Applicable geospatial features could not be selected because one or more filter criteria are not supported by the USS.  If this value is specified, `message` must be populated.
+            * Error: An error or condition not enumerated above occurred.  If this value is specified, `message` must be populated.
+          enum:
+            - Present
+            - Absent
+            - UnsupportedFilter
+            - Error
+        message:
+          type: string
+          description: >-
+            A human-readable description of why the unsuccessful `featuresSelectionOutcome` was reported.  Should only be populated when appropriate according to the value of the `featuresSelectionOutcome` field.
+          example: >-
+            ED-269 comprehension is not supported.
+
+paths:
+  /status:
+    get:
+      operationId: GetStatus
+      security:
+        - TestAuthority:
+            - interuss.geospatial_map.direct_automated_test
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+          description: >-
+            The USS automated testing interface is available and its status was retrieved successfully.
+        '401':
+          description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+        '403':
+          description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+        '404':
+          description: The USS automated testing interface is not available.
+      summary: Status of the USS automated testing interface
+      description: Get the status of the USS automated testing interface.
+
+  /geospatial_data_sources/{geospatial_data_source_id}:
+    parameters:
+      - name: geospatial_data_source_id
+        in: path
+        required: true
+        description: A UUID string identifying a geospatial data source.
+        schema:
+          $ref: '#/components/schemas/UUIDv4Format'
+
+    put:
+      security:
+        - TestAuthority:
+            - interuss.geospatial_map.direct_automated_test
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateGeospatialDataSourceRequest'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeospatialDataSourceResponse'
+          description: >-
+            Request has been correctly handled and the USS has been instructed to import and activate the geospatial data from the source.
+        '401':
+          description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+        '403':
+          description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+      operationId: PutGeospatialDataSource
+      summary: Import and activate a geospatial data source
+      description: Instructs the USS to import and activate the geospatial data from the specified source.
+
+    get:
+      security:
+        - TestAuthority:
+            - interuss.geospatial_map.direct_automated_test
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeospatialDataSourceResponse'
+          description: >-
+            The geospatial data source is known by the USS and its status was retrieved successfully.
+        '401':
+          description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+        '403':
+          description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+        '404':
+          description: The geospatial data source has been successfully deactivated or didn't exist.
+      operationId: GetGeospatialDataSourceStatus
+      summary: Status of a geospatial data source
+      description: Get the status of the geospatial data source in the USS.
+
+    delete:
+      security:
+        - TestAuthority:
+            - interuss.geospatial_map.direct_automated_test
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeospatialDataSourceResponse'
+          description: >-
+            Request has been correctly handled and the geospatial dataset may be deleted by the USS.
+            Status of the dataset may be checked using the GET method until it returns a 404.
+        '401':
+          description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+        '403':
+          description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+      operationId: DeleteGeospatialDataSource
+      summary: Deactivate a geospatial data source
+      description: Instructs the USS to deactivate the geospatial data source and its data.
+
+  /map/queries:
+    post:
+      security:
+        - TestAuthority:
+            - interuss.geospatial_map.query
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GeospatialMapQueryRequest'
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeospatialMapQueryReply'
+          description: >-
+            The query was successfully performed.
+        '401':
+          description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+        '403':
+          description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+      operationId: QueryGeospatialMap
+      summary: Check for applicable geospatial features
+      description: Check if one or multiple geospatial features are applicable at the position of interest for the specified period of time and operational conditions.


### PR DESCRIPTION
In response to UJ5 in [the accepted proposal for a geospatial comprehension test feature](https://github.com/interuss/tsc/pull/7), this PR establishes a new "geospatial map" automated testing interface.  This interface is an incremental change content-wise from the geo-awareness API, but it has many terminology, philosophy, and field naming changes from that API, so this PR intends to deprecate the geo-awareness API in favor of this geospatial map API.  It should be easy to adapt any tests currently using the geo-awareness API to use the geospatial map API instead as the geospatial map API conceptually derives from the geo-awareness API.

Perhaps the key difference from the geo-awareness API to the geospatial map API is the conceptualization: geospatial map explicitly conceptualizes the operations as user interactions with the USS's virtual geospatial map, which should be a general concept that can be applied to U-space geo-awareness and Geozones specifically (but also other map-related applications in other jurisdictions).  Based on this shift, "Geozone" is generally replaced with "geospatial feature" (Geozones are special kinds of geospatial features).  The endpoint paths are also adjusted for this reason.

Two separate scopes are used to differentiate the test director acting as a test director (can interrogate the status and version of the system, request data loading, etc) and the test director acting as a user "viewing" the USS's geospatial map (can only "view"/inspect/query the USS's map).

api_name and api_version are added so that uss_qualifier can determine whether a provided interface implementation will work -- this anticipates updates to the API that may not be implemented immediately by USSs.  So, for instance, if the most recent API version were 1.1.3 and a USS provided an implementation of the 1.0.2 API, some steps of uss_qualifier may be able to proceed while other steps may require the features added in 1.1.0 of the API.

Some USSs may have difficulty returning 404 for a recognized resource, so a "Deactivated" state is added to the geospatial data source resource as an alternative to returning 404.

GeospatialFeatureFilterSet is updated to add a number of fields from UJ5 in the document linked above.

ED-269 and ASTM F3548-21 data structures are moved into their own YAML files $ref'd into the primary interface YAML for clarity.