### PR TITLE
Add flight_planning interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,5 +11,7 @@ This repository houses the interfaces a USS/USSP must implement in order to be t
     * [v1 YAML](rid/v1/injection.yaml)
   * Observation (for NetRID Display Providers/Display Applications)
     * [v1 YAML](rid/v1/observation.yaml)
-* [Flight planning](scd/README.md)
+* [SCD](scd/README.md) (will be deprecated; see [flight planning](flight_planning) instead)
   * [v1 YAML](scd/v1/scd.yaml)
+* [Flight planning](flight_planning/README.md)
+  * [v1 YAML](flight_planning/v1/flight_planning.yaml)

--- a/flight_planning/README.md
+++ b/flight_planning/README.md
@@ -1,0 +1,29 @@
+# Flight planning automated testing interface
+
+This folder contains the [USSP interface for flight planning automated testing](v1/flight_planning.yaml).
+
+## Overview
+
+This interface is designed to support the following scenario:
+> I (the test director, acting like a normal client operator) want to
+> 
+> * Plan a flight with the specified characteristics
+> * Update an existing flight plan to the new specified characteristics
+> * Close an existing flight plan
+>
+> You (the USSP under test) attempt to fulfill this request, in the same way as if a normal client operator made the same request, and indicate the result.
+
+It also supports other actions likely associated with tests involving flight planning, such as the test director requesting and ensuring that the USSP under test has loaded a particular geospatial dataset.
+
+This interface supports testing of the U-space Flight Authorisation service and other similar services.
+
+## Viewing locally
+To view a description of this interface locally, from this folder:
+
+```shell script
+docker run -it --rm -p 8080:8080 \
+  -v $(pwd)/:/usr/share/nginx/html/api/ \
+  -e PORT=8080 -e SPEC_URL=./api/v1/flight_planning.yaml redocly/redoc
+```
+
+...then visit [http://localhost:8080/](http://localhost:8080/) in a browser.

--- a/flight_planning/v1/astm_f3548_21.yaml
+++ b/flight_planning/v1/astm_f3548_21.yaml
@@ -80,12 +80,11 @@ components:
         reference:
           description: >-
             A code indicating the reference for a vertical distance. See AIXM
-            5.1 and FIXM 4.2.0. Currently, UTM only allows WGS84 with no
-            immediate plans to allow other options. FIXM and AIXM allow for
-            'SFC' which is equivalent to AGL.
+            5.1 and FIXM 4.2.0.
           type: string
           enum:
             - W84
+            - SFC
         units:
           description: >-
             The reference quantities used to express the value of altitude. See

--- a/flight_planning/v1/astm_f3548_21.yaml
+++ b/flight_planning/v1/astm_f3548_21.yaml
@@ -1,0 +1,214 @@
+openapi: 3.0.2
+info:
+  title: Definitions used in flight planning interface designed to align with data structures from ASTM F3548-21
+components:
+  schemas:
+    UUIDv4Format:
+      description: >-
+        String whose format matches a version-4 UUID according to RFC 4122.
+      maxLength: 36
+      minLength: 36
+      type: string
+      format: uuid
+      pattern: >-
+        ^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$
+      example: 03e5572a-f733-49af-bc14-8a18bd53ee39
+    EntityID:
+      description: >-
+        Identifier for an Entity communicated through the DSS.  Formatted as a
+        UUIDv4.
+      anyOf:
+        - $ref: '#/components/schemas/UUIDv4Format'
+      example: 2f8343be-6482-4d1b-a474-16847e01af1e
+    Time:
+      required:
+        - value
+        - format
+      type: object
+      properties:
+        value:
+          type: string
+          description: >-
+            RFC3339-formatted time/date string.  The time zone must be 'Z'.
+          format: date-time
+          example: '1985-04-12T23:20:50.52Z'
+        format:
+          type: string
+          enum:
+            - RFC3339
+
+    Radius:
+      required:
+        - value
+        - units
+      type: object
+      properties:
+        value:
+          format: float
+          description: >-
+            Distance from the centerpoint of a circular area, along the WGS84
+            ellipsoid.
+          type: number
+          minimum: 0
+          exclusiveMinimum: true
+          example: 300.183
+        units:
+          type: string
+          description: >-
+            FIXM-compatible units.  Only meters ("M") are acceptable for UTM.
+          enum:
+            - M
+    Altitude:
+      type: object
+      required:
+        - value
+        - reference
+        - units
+      properties:
+        value:
+          description: >-
+            The numeric value of the altitude. Note that min and max values are
+            added as a sanity check. As use cases evolve and more options are
+            made available in terms of units of measure or reference systems,
+            these bounds may be re-evaluated.
+          type: number
+          format: double
+          minimum: -8000
+          exclusiveMinimum: false
+          maximum: 100000
+          exclusiveMaximum: false
+        reference:
+          description: >-
+            A code indicating the reference for a vertical distance. See AIXM
+            5.1 and FIXM 4.2.0. Currently, UTM only allows WGS84 with no
+            immediate plans to allow other options. FIXM and AIXM allow for
+            'SFC' which is equivalent to AGL.
+          type: string
+          enum:
+            - W84
+        units:
+          description: >-
+            The reference quantities used to express the value of altitude. See
+            FIXM 4.2. Currently, UTM only allows meters with no immediate plans
+            to allow other options.
+          type: string
+          enum:
+            - M
+    Latitude:
+      description: >-
+        Degrees of latitude north of the equator, with reference to the WGS84
+        ellipsoid.
+      maximum: 90
+      exclusiveMaximum: false
+      minimum: -90
+      exclusiveMinimum: false
+      type: number
+      format: double
+      example: 34.123
+    Longitude:
+      description: >-
+        Degrees of longitude east of the Prime Meridian, with reference to the
+        WGS84 ellipsoid.
+      minimum: -180
+      exclusiveMaximum: false
+      maximum: 180
+      exclusiveMinimum: false
+      type: number
+      format: double
+      example: -118.456
+    Polygon:
+      description: >-
+        An enclosed area on the earth. The bounding edges of this polygon are
+        defined to be the shortest paths between connected vertices.  This
+        means, for instance, that the edge between two points both defined at a
+        particular latitude is not generally contained at that latitude. The
+        winding order must be interpreted as the order which produces the
+        smaller area. The path between two vertices is defined to be the
+        shortest possible path between those vertices. Edges may not cross.
+        Vertices may not be duplicated.  In particular, the final polygon vertex
+        must not be identical to the first vertex.
+      required:
+        - vertices
+      type: object
+      properties:
+        vertices:
+          minItems: 3
+          type: array
+          items:
+            $ref: '#/components/schemas/LatLngPoint'
+    LatLngPoint:
+      description: Point on the earth's surface.
+      required:
+        - lat
+        - lng
+      type: object
+      properties:
+        lng:
+          $ref: '#/components/schemas/Longitude'
+        lat:
+          $ref: '#/components/schemas/Latitude'
+    Circle:
+      description: A circular area on the surface of the earth.
+      type: object
+      properties:
+        center:
+          $ref: '#/components/schemas/LatLngPoint'
+        radius:
+          $ref: '#/components/schemas/Radius'
+    Volume3D:
+      description: >-
+        A three-dimensional geographic volume consisting of a
+        vertically-extruded shape. Exactly one outline must be specified.
+      type: object
+      properties:
+        outline_circle:
+          anyOf:
+            - $ref: '#/components/schemas/Circle'
+          description: A circular geographic shape on the surface of the earth.
+        outline_polygon:
+          anyOf:
+            - $ref: '#/components/schemas/Polygon'
+          description: >-
+            A polygonal geographic shape on the surface of the earth.
+        altitude_lower:
+          description: >-
+            Minimum bounding altitude of this volume. Must be less than
+            altitude_upper, if specified.
+          anyOf:
+            - $ref: '#/components/schemas/Altitude'
+        altitude_upper:
+          description: >-
+            Maximum bounding altitude of this volume. Must be greater than
+            altitude_lower, if specified.
+          anyOf:
+            - $ref: '#/components/schemas/Altitude'
+    Volume4D:
+      description: Contiguous block of geographic spacetime.
+      required:
+        - volume
+      type: object
+      properties:
+        volume:
+          $ref: '#/components/schemas/Volume3D'
+        time_start:
+          description: Beginning time of this volume. Must be before time_end.
+          anyOf:
+            - $ref: '#/components/schemas/Time'
+        time_end:
+          description: End time of this volume. Must be after time_start.
+          anyOf:
+            - $ref: '#/components/schemas/Time'
+    OperationalIntentState:
+      description: >-
+        State of an operational intent as defined in ASTM F3548-21.
+      type: string
+      enum:
+        - Accepted
+        - Activated
+        - Nonconforming
+        - Contingent
+    Priority:
+      description: >-
+        Ordinal priority of the operational intent, as defined in ASTM F3548-21.
+      type: integer
+      default: 0

--- a/flight_planning/v1/au.yaml
+++ b/flight_planning/v1/au.yaml
@@ -3,9 +3,9 @@ info:
   title: Australia-specific flight planning information schemas.
 components:
   schemas:
-    AUFlightDetails:
+    RPAS26FlightDetails:
       description: >-
-        Information about a flight necessary to plan successfully in Australia.
+        Information about a flight necessary to plan successfully using the RPAS Platform Operating Rules version 2.6.
       type: object
       properties:
         operator_type:

--- a/flight_planning/v1/au.yaml
+++ b/flight_planning/v1/au.yaml
@@ -1,0 +1,63 @@
+openapi: 3.0.2
+info:
+  title: Australia-specific flight planning information schemas.
+components:
+  schemas:
+    AUFlightDetails:
+      description: >-
+        Information about a flight necessary to plan successfully in Australia.
+      type: object
+      properties:
+        operator_type:
+          description: The type of operator.
+          type: string
+          enum:
+            - Recreational
+            - CommercialExcluded
+            - ReOC
+        uas_serial_numbers:
+          description: The list of UAS/drone serial numbers that will be operated during the operation.
+          type: array
+          items:
+            type: string
+        uas_registration_numbers:
+          description: The list of UAS/drone registration numbers that will be operated during the operation.
+          type: array
+          items:
+            type: string
+        aircraft_type:
+          description: Type of vehicle being used as per ASTM F3411-22a.
+          type: string
+          enum:
+            - NotDeclared
+            - Aeroplane
+            - Helicopter
+            - Gyroplane
+            - HybridLift
+            - Ornithopter
+            - Glider
+            - Kite
+            - FreeBalloon
+            - CaptiveBalloon
+            - Airship
+            - FreeFallOrParachute
+            - Rocket
+            - TetheredPoweredAircraft
+            - GroundObstacle
+            - Other
+        flight_profile:
+          description: Type of flight profile.
+          type: string
+          enum:
+            - AutomatedGrid
+            - AutomatedWaypoint
+            - Manual
+        pilot_license_number:
+          description: License number for the pilot.
+          type: string
+        pilot_phone_number:
+          description: Contact phone number for the pilot.
+          type: string
+        operator_number:
+          description: Operator number.
+          type: string

--- a/flight_planning/v1/flight_planning.yaml
+++ b/flight_planning/v1/flight_planning.yaml
@@ -92,10 +92,10 @@ components:
           description: >-
             User's current usage of the flight plan.
             
-            'Planned': The user intends to fly according to this flight plan, but is not currently using the defined
+            `Planned`: The user intends to fly according to this flight plan, but is not currently using the defined
               area with an active UAS.
             
-            'InUse': The user is currently using the defined area with an active UAS.
+            `InUse`: The user is currently using the defined area with an active UAS.
           type: string
           enum:
             - Planned
@@ -104,12 +104,12 @@ components:
           description: >-
             State of the user's UAS associated with this flight plan.
             
-              - 'Nominal': The user or UAS reports or implies that it is performing nominally.
+              - `Nominal`: The user or UAS reports or implies that it is performing nominally.
             
-              - 'OffNominal': The user or UAS reports or implies that it is temporarily not performing nominally, but
+              - `OffNominal`: The user or UAS reports or implies that it is temporarily not performing nominally, but
                 expects to be able to recover to normal operation.
             
-              - 'Contingent': The user or UAS reports or implies that it is not performing nominally and may be unable
+              - `Contingent`: The user or UAS reports or implies that it is not performing nominally and may be unable
                 to recover to normal operation.
           type: string
           enum:
@@ -176,11 +176,11 @@ components:
             Indication of whether any advisories or conditions were provided to the user along with the result of this
             flight planning attempt.
             
-              - 'Unknown': It is unknown or irrelevant whether advisories or conditions were provided to the user
+              - `Unknown`: It is unknown or irrelevant whether advisories or conditions were provided to the user
 
-              - 'Yes': At least one advisory or condition was provided to the user.
+              - `Yes`: At least one advisory or condition was provided to the user.
             
-              - 'No': No advisories or conditions were provided to the user.
+              - `No`: No advisories or conditions were provided to the user.
           type: string
           enum:
             - Unknown

--- a/flight_planning/v1/flight_planning.yaml
+++ b/flight_planning/v1/flight_planning.yaml
@@ -10,6 +10,9 @@ info:
     
     The client may also (with a separate authorization scope) act as the test director to determine the status of the
     USS's system under test, and request that the test area be cleared of any dangling flight plans.
+    
+    Note: Unless otherwise specified, fields specified in a message but not declared in the API or otherwise known to
+    the server or client (as applicable) must be ignored.
 
 components:
   securitySchemes:
@@ -73,8 +76,8 @@ components:
           $ref: './scd.yaml#/components/schemas/ASTMF354821OpIntentInformation'
         uspace_flight_authorisation:
           $ref: './uspace.yaml#/components/schemas/FlightAuthorisationData'
-        au:
-          $ref: './au.yaml#/components/schemas/AUFlightDetails'
+        rpas_operating_rules_2_6:
+          $ref: './au.yaml#/components/schemas/RPAS26FlightDetails'
         additional_information:
           description: >-
             Any information relevant to a particular jurisdiction or use case not described in the standard schema. The
@@ -139,9 +142,16 @@ components:
       type: object
       required:
         - intended_flight
+        - request_id
       properties:
         intended_flight:
           $ref: '#/components/schemas/FlightPlan'
+        request_id:
+          description: >-
+            ID uniquely identifying the upsertion request.  If additional requests are received with the same
+            request_id, the response from the first request should be returned, or an error indicated.
+          anyOf:
+            - $ref: './astm_f3548_21.yaml#/components/schemas/UUIDv4Format'
 
     UpsertFlightPlanResponse:
       type: object
@@ -234,8 +244,6 @@ components:
             - $ref: './astm_f3548_21.yaml#/components/schemas/Volume4D'
     ClearAreaOutcome:
       type: object
-      required:
-        - timestamp
       properties:
         success:
           description: >-
@@ -318,7 +326,7 @@ paths:
         required: true
         description: A UUID string identifying the user's flight plan intent.
         schema:
-          $ref: '#/components/schemas/UUIDv4Format'
+          $ref: './astm_f3548_21.yaml#/components/schemas/UUIDv4Format'
 
     put:
       security:
@@ -342,6 +350,8 @@ paths:
           description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
         '403':
           description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+        '409':
+          description: The request contains a duplicate request_id and the response for that request is not available, or another conflict condition occurred.
 
       summary: Upsert flight plan
       operationId: UpsertFlightPlan

--- a/flight_planning/v1/flight_planning.yaml
+++ b/flight_planning/v1/flight_planning.yaml
@@ -1,0 +1,367 @@
+openapi: 3.0.2
+info:
+  title: Flight Planning Automated Testing Interface
+  version: 0.1.0
+  description: >-
+    This interface is implemented by a USS wishing to participate in automated tests involving attempts to plan flights.
+    
+    The client (usually uss_qualifier) pretends to be a user interacting with the USS's flight planning user interface
+    attempting to plan, update, and close flight plans.
+    
+    The client may also (with a separate authorization scope) act as the test director to determine the status of the
+    USS's system under test, and request that the test area be cleared of any dangling flight plans.
+
+components:
+  securitySchemes:
+    Authority:
+      type: oauth2
+      flows:
+        clientCredentials:
+          tokenUrl: https://auth.example.com/oauth/token
+          scopes:
+            interuss.flight_planning.direct_automated_test: |-
+              Client may determine the test-readiness of the USS and instruct the USS to perform various actions to
+              prepare for tests involving flight planning (acting as test director).
+            interuss.flight_planning.plan: |-
+              Client may act as a user attempting to plan a flight, modify an existing flight plan, or close an existing
+              flight plan.
+      description: |-
+        Authorization from, or on behalf of, an authorization authority, augmenting standard strategic conflict detection or other similar authorization for the purpose of automated testing.
+
+  schemas:
+    StatusResponse:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          description: >-
+            The status of the USS automated testing interface.
+
+            - `Starting`: the USS is starting and the automated test driver should wait before sending requests.
+
+            - `Ready`: the USS is ready to receive test requests.
+          type: string
+          enum: [Starting, Ready]
+          example: Ready
+        system_version:
+          description: |-
+            Arbitrary string representing the version of the USS system to be tested.
+          type: string
+          example: v0.0.1-445ad3
+        api_name:
+          description: |-
+            Indication of the API implemented at this URL.  Must be "Flight Planning Automated Testing Interface".
+          type: string
+          example: Flight Planning Automated Testing Interface
+        api_version:
+          description: |-
+            Indication of the API version implemented at this URL.  Must be "v0.1.0" when implementing this version of the API.
+          type: string
+          example: v0.1.0
+
+    FlightPlan:
+      description: >-
+        Details of user's intent to create or modify a flight plan.
+      required:
+        - basic_information
+      type: object
+      properties:
+        basic_information:
+          $ref: '#/components/schemas/BasicFlightPlanInformation'
+        astm_f3548_21:
+          $ref: './scd.yaml#/components/schemas/ASTMF354821OpIntentInformation'
+        uspace_flight_authorisation:
+          $ref: './uspace.yaml#/components/schemas/FlightAuthorisationData'
+        additional_information:
+          description: >-
+            Any information relevant to a particular jurisdiction or use case not described in the standard schema. The
+            keys and values must be agreed upon between the test designers and USSs under test.
+          type: object
+
+    BasicFlightPlanInformation:
+      description: >-
+        Basic information about a flight plan that an operator and/or UAS can be expected to provide in most flight
+        planning scenarios.
+      type: object
+      required:
+        - usage_state
+        - uas_state
+      properties:
+        usage_state:
+          description: >-
+            User's current usage of the flight plan.
+            
+            'Planned': The user intends to fly according to this flight plan, but is not currently using the defined
+              area with an active UAS.
+            
+            'InUse': The user is currently using the defined area with an active UAS.
+          type: string
+          enum:
+            - Planned
+            - InUse
+        uas_state:
+          description: >-
+            State of the user's UAS associated with this flight plan.
+            
+              - 'Nominal': The user or UAS reports or implies that it is performing nominally.
+            
+              - 'OffNominal': The user or UAS reports or implies that it is temporarily not performing nominally, but
+                expects to be able to recover to normal operation.
+            
+              - 'Contingent': The user or UAS reports or implies that it is not performing nominally and may be unable
+                to recover to normal operation.
+          type: string
+          enum:
+            - Nominal
+            - OffNominal
+            - Contingent
+        nominal_area:
+          description: >-
+            User nominally intends or intended to fly in this entire area.  If authorizations are required and cannot be
+            granted to cover this entire area, the plan should be rejected.
+          type: array
+          items:
+            $ref: './astm_f3548_21.yaml#/components/schemas/Volume4D'
+          default: []
+        off_nominal_area:
+          description: >-
+            While experiencing an off-nominal situation, the user's aircraft may travel anywhere in this area.  If the
+            flight_state is nominal, this field must be empty or omitted.
+          type: array
+          items:
+            $ref: './astm_f3548_21.yaml#/components/schemas/Volume4D'
+          default: []
+
+    UpsertFlightPlanRequest:
+      type: object
+      properties:
+        intended_flight:
+          $ref: '#/components/schemas/FlightPlan'
+
+    UpsertFlightPlanResponse:
+      type: object
+      required:
+        - result
+      properties:
+        result:
+          description: >-
+            The result of the flight plan submission.
+            If any option other than `Planned` or `ReadyToFly` is specified, the `notes` field should be populated with the reason for the unsuccessful outcome.
+
+              - `Planned`: The data submitted in the flight plan intent was valid and the flight plan was successfully processed by the USS and is now authorized, but the user may not yet start flying (even if within the time bounds of the flight plan).
+
+              - `ReadyToFly`: The flight plan is ready for the operator to begin flying within the bounds (including time) of the flight plan.
+
+              - `Rejected`: The data provided in the flight plan was invalid and/or could not be used to successfully authorize the flight.  The reason for rejection may include a disallowed conflict with another flight.
+
+              - `Failed`: The USS was not able to successfully authorize the flight plan due to a problem with the USS or a downstream system
+            
+              - `NotSupported`: The USS does not support the attempted interaction.  For instance, if the request specified a high-priority flight and the USS does not support management of high-priority flights.
+          type: string
+          enum: [Planned, ReadyToFly, Rejected, Failed, NotSupported]
+          example: Planned
+        notes:
+          description: >-
+            Human-readable explanation of the observed result.  This explanation
+            may be made available to a human reviewing the test results, and
+            ideally should explain why an undesirable result was obtained.  For
+            instance, if the injection attempt Failed, then these notes may
+            indicate that the attempt failed because the DSS indicated 400 to a
+            valid request (perhaps also including the valid request as proof).
+          type: string
+          example: Requested flight intersected operational intent c036326c-c97b-4926-bf9f-c60dc83d2b57
+        includes_advisories:
+          description: >-
+            Indication of whether any advisories or conditions were provided to the user along with the result of this
+            flight planning attempt.
+            
+              - 'Unknown': It is unknown or irrelevant whether advisories or conditions were provided to the user
+
+              - 'Yes': At least one advisory or condition was provided to the user.
+            
+              - 'No': No advisories or conditions were provided to the user.
+          type: string
+          enum:
+            - Unknown
+            - Yes
+            - No
+          default: Unknown
+          example: No
+
+    DeleteFlightPlanResponse:
+      type: object
+      required:
+        - result
+      properties:
+        result:
+          description: >-
+            The result of attempted flight plan cancellation/closure.
+
+              - `Closed`: The flight plan was closed successfully by the USS and is now out of the UTM system.
+
+              - `Failed`: The flight plan could not be closed successfully by the USS.
+          enum: [Closed, Failed]
+          example: Failed
+        notes:
+          description: >-
+            Human-readable explanation of the observed result.
+          type: string
+          example: DSS was unreachable when attempting to delete operational intent reference
+
+    ClearAreaRequest:
+      type: object
+      required:
+        - request_id
+        - extent
+      properties:
+        request_id:
+          description: >-
+            Unique string identifying this request.  If a second request with an
+            identical ID is received, the USS may return the same response from
+            the previous operation rather than attempting to clear the area
+            again (the USS may also attempt to clear the area again).
+          type: string
+        extent:
+          description: >-
+            The USS should cancel and remove any flight plan where any part of that
+            flight plan intersects this area.
+          anyOf:
+            - $ref: './astm_f3548_21.yaml#/components/schemas/Volume4D'
+    ClearAreaOutcome:
+      type: object
+      required:
+        - timestamp
+      properties:
+        success:
+          description: >-
+            True if, and only if, all flight plans in the specified area managed by the
+            USS were canceled and removed.
+          type: boolean
+          default: false
+        message:
+          description: >-
+            If the USS was unable to clear the entire area, this message can
+            provide information on the problem encountered.
+          type: string
+          example: >-
+            DSS at dss.example.com returned 500 when attempting to delete
+            operational intent 57e98b17-aefa-4eee-a376-5140e4a8385f
+    ClearAreaResponse:
+      type: object
+      required:
+        - outcome
+      properties:
+        outcome:
+          $ref: '#/components/schemas/ClearAreaOutcome'
+
+paths:
+  /status:
+    get:
+      security:
+        - Authority:
+            - interuss.flight_planning.direct_automated_test
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StatusResponse'
+          description: >-
+            The USS automated testing interface is available and its status was retrieved successfully.
+        '401':
+          description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+        '403':
+          description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+        '404':
+          description: The USS automated testing interface is not available.
+      summary: Status of the USS automated testing interface
+      description: Get the status of the USS automated testing interface.
+
+  /clear_area_requests:
+    post:
+      security:
+        - Authority:
+            - interuss.flight_planning.direct_automated_test
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ClearAreaRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ClearAreaResponse'
+          description: Requested area was cleared successfully
+        '401':
+          description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+        '403':
+          description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+
+      summary: Clear area
+      operationId: ClearArea
+      description: >-
+        This endpoint requests that the USS cancel and remove all flight plans in the specified area.
+
+  /flight_plans/{flight_plan_id}:
+    parameters:
+      - name: flight_plan_id
+        in: path
+        required: true
+        description: A UUID string identifying the user's flight plan intent.
+        schema:
+          $ref: '#/components/schemas/UUIDv4Format'
+
+    put:
+      security:
+        - Authority:
+            - interuss.flight_planning.plan
+
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpsertFlightPlanRequest'
+        required: true
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UpsertFlightPlanResponse'
+          description: Requested data was processed successfully
+        '401':
+          description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+        '403':
+          description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+
+      summary: Upsert flight plan
+      operationId: UpsertFlightPlan
+      description: >-
+        This endpoint simulates an operator intention to submit a new or updated flight plan.
+
+    delete:
+      security:
+        - Authority:
+            - interuss.flight_planning.plan
+
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DeleteFlightPlanResponse'
+          description: Flight plan was closed successfully
+        '401':
+          description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+        '403':
+          description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+
+      summary: Close flight plan
+      operationId: DeleteFlightPlan
+      description: >-
+        This endpoint simulates the operator intention to cancel, end, or close a flight plan.

--- a/flight_planning/v1/flight_planning.yaml
+++ b/flight_planning/v1/flight_planning.yaml
@@ -374,6 +374,8 @@ paths:
           description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
         '403':
           description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+        '404':
+          description: The specified flight plan could not be found (it may have already been deleted).
 
       summary: Close flight plan
       operationId: DeleteFlightPlan

--- a/flight_planning/v1/flight_planning.yaml
+++ b/flight_planning/v1/flight_planning.yaml
@@ -73,6 +73,8 @@ components:
           $ref: './scd.yaml#/components/schemas/ASTMF354821OpIntentInformation'
         uspace_flight_authorisation:
           $ref: './uspace.yaml#/components/schemas/FlightAuthorisationData'
+        au:
+          $ref: './au.yaml#/components/schemas/AUFlightDetails'
         additional_information:
           description: >-
             Any information relevant to a particular jurisdiction or use case not described in the standard schema. The
@@ -135,6 +137,8 @@ components:
 
     UpsertFlightPlanRequest:
       type: object
+      required:
+        - intended_flight
       properties:
         intended_flight:
           $ref: '#/components/schemas/FlightPlan'

--- a/flight_planning/v1/scd.yaml
+++ b/flight_planning/v1/scd.yaml
@@ -1,0 +1,14 @@
+openapi: 3.0.2
+info:
+  title: Definitions used in flight planning interface specific to strategic conflict detection, but not using data structures aligned with ones defined in ASTM F3548-21.
+components:
+  schemas:
+    Foo:
+      type: object
+    ASTMF354821OpIntentInformation:
+      description: >-
+        Information provided about a flight plan that is necessary for ASTM F3548-21.
+      type: object
+      properties:
+        priority:
+          $ref: './astm_f3548_21.yaml#/components/schemas/Priority'

--- a/flight_planning/v1/uspace.yaml
+++ b/flight_planning/v1/uspace.yaml
@@ -1,0 +1,106 @@
+openapi: 3.0.2
+info:
+  title: Definitions used in flight planning interface specific to U-space flight authorisation.
+components:
+  schemas:
+    FlightAuthorisationData:
+      description: |-
+        The details of a UAS flight authorization request, as received from the user.
+        
+        Note that a full description of a flight authorisation must include mandatory information required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664 for an UAS flight authorisation request. Reference: https://eur-lex.europa.eu/legal-content/EN/TXT/HTML/?uri=CELEX:32021R0664&from=EN#d1e32-178-1
+      type: object
+      properties:
+        uas_serial_number:
+          type: string
+          description: Unique serial number of the unmanned aircraft or, if the unmanned aircraft is privately built, the unique serial number of the add-on. This is expressed in the ANSI/CTA-2063 Physical Serial Number format. Required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 1.
+          example: MFR1C123456789ABC
+        operation_mode:
+          $ref: '#/components/schemas/OperationMode'
+        operation_category:
+          type: string
+          enum:
+            - Unknown
+            - Open
+            - Specific
+            - Certified
+          description: |-
+            Category of UAS operation (‘open’, ‘specific’, ‘certified’) as defined in COMMISSION DELEGATED REGULATION (EU) 2019/945. Required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 4.
+          example: Open
+        uas_class:
+          $ref: '#/components/schemas/UASClass'
+        identification_technologies:
+          type: array
+          items:
+            type: string
+          description: Technology used to identify the UAS. Required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 6.
+          example: ['ADS-B', 'ASTMNetRID']
+        uas_type_certificate:
+          description: |-
+            Provisional field. Not applicable as of September 2021. Required only if `uas_class` is set to `other` by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 4.
+          type: string
+          example: ''
+        connectivity_methods:
+          type: array
+          items:
+            type: string
+          description: Connectivity methods. Required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 7.
+          example: ['cellular']
+        endurance_minutes:
+          description: Endurance of the UAS. This is expressed in minutes. Required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 8.
+          type: number
+          format: int32
+          example: 20
+        emergency_procedure_url:
+          type: string
+          format: url
+          description: The URL at which the applicable emergency procedure in case of a loss of command and control link may be retrieved. Required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 9.
+          example: https://utm_uss.com/emergency_procedure
+        operator_id:
+          type: string
+          description: |-
+            Registration number of the UAS operator.
+            The format is defined in EASA Easy Access Rules for Unmanned Aircraft Systems GM1 to AMC1
+            Article 14(6) Registration of UAS operators and ‘certified’ UAS.
+            Required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 10.
+          example: FIN87astrdge12k8
+        uas_id:
+          description: |-
+            When applicable, the registration number of the unmanned aircraft.
+            This is expressed using the nationality and registration mark of the unmanned aircraft in
+            line with ICAO Annex 7.
+            Specified by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 10.
+          type: string
+          example: HB-XXXX
+      required:
+        - uas_serial_number
+        - operation_mode
+        - uas_class
+        - identification_technologies
+        - operator_id
+        - operation_category
+        - connectivity_methods
+        - endurance_minutes
+        - emergency_procedure_url
+
+    OperationMode:
+      type: string
+      enum:
+        - Undeclared
+        - Vlos
+        - Bvlos
+      description: Specify if the operation is a `VLOS` or `BVLOS` operation. Required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 2.
+      example: Vlos
+
+    UASClass:
+      type: string
+      enum:
+        - Other
+        - C0
+        - C1
+        - C2
+        - C3
+        - C4
+        - C5
+        - C6
+      description: Specify the class of the UAS to be flown, the specifition matches EASA class identification label categories. UAS aircraft class as defined in COMMISSION DELEGATED REGULATION (EU) 2019/945 (C0 to C4) and COMMISSION DELEGATED REGULATION (EU) 2020/1058 (C5 and C6). This field is required by ANNEX IV of COMMISSION IMPLEMENTING REGULATION (EU) 2021/664, paragraph 4.
+      example: C0

--- a/scd/README.md
+++ b/scd/README.md
@@ -1,5 +1,10 @@
 # Flight planning automated testing interface
 
+---
+Note: This interface will be DEPRECATED and REMOVED.  The replacement interface will be the [flight planning interface](../flight_planning).
+
+---
+
 This folder contains the [USSP interface for flight planning automated testing](v1/scd.yaml).
 
 ## Overview

--- a/scd/v1/scd.yaml
+++ b/scd/v1/scd.yaml
@@ -567,6 +567,7 @@ components:
 paths:
   /v1/status:
     get:
+      deprecated: true
       security:
         - Authority:
             - utm.inject_test_data
@@ -589,6 +590,7 @@ paths:
 
   /v1/capabilities:
     get:
+      deprecated: true
       security:
       - Authority:
           - utm.inject_test_data
@@ -617,6 +619,7 @@ paths:
         $ref: '#/components/schemas/UUIDv4Format'
 
     put:
+      deprecated: true
       security:
         - Authority:
             - utm.inject_test_data
@@ -645,6 +648,7 @@ paths:
         This endpoint simulates the operator intention to submit a flight operation / flight request.
 
     delete:
+      deprecated: true
       security:
       - Authority:
         - utm.inject_test_data
@@ -668,6 +672,7 @@ paths:
 
   /v1/clear_area_requests:
     post:
+      deprecated: true
       security:
       - Authority:
         - utm.inject_test_data


### PR DESCRIPTION
In response to UJ6 in [the accepted proposal for a geospatial comprehension test feature](https://github.com/interuss/tsc/pull/7), this PR establishes a new "flight planning" automated testing interface.  This interface is similar to the existing SCD (also called "flight planning" in some cases) API, but it has many terminology, philosophy, and field naming changes from that API, and a few substantive changes, so this PR anticipates deprecating the SCD API in the future in favor of this flight planning API.  For the most part (except one exception mentioned below), it shouldn't be too hard to adapt any tests currently using the SCD API to use this flight planning API instead as this flight planning API conceptually derives from the SCD API.

Perhaps the key difference from the SCD API to the flight planning API is the conceptualization: flight planning explicitly conceptualizes the operations as user interactions with the USS's flight planning capability, which should be a general concept that can be applied to U-space flight authorisation specifically (but also other flight-planning applications in other jurisdictions).  This is in contrast to the SCD API which often represents that it is an injection of ASTM F3548-21 operational intents into the USS.  Flight planning is more general and user-based; the user may not have any awareness of ASTM F3548-21, and in some flight planning scenarios, ASTM F3548-21 may not be used at all.  The "flight" of the SCD API, which effectively mapped directly to an ASTM F3548-21 operational intent, is therefore replaced with a "flight plan" in this flight planning API, this "flight plan" is intentionally not necessarily associated with an operational intent.  Based on this shift, "flight" is generally replaced with "flight plan".  The endpoint paths are also adjusted for this reason.

The fundamental information an operator would reasonably be expected to provide (directly or indirectly) is grouped in basic_information, and then any additional information for special purposes (including ASTM F3548-21 and U-space) are grouped in sibling fields labeled according to the special purposes.  Some fields from Operation Details in Annex 5 of the document linked above are not included in this PR with the thought that, for instance, "UAS registration number" may mean different things in different contexts, and there is not necessarily a single UAS registration number that an operator would necessarily provide.  When the schema for a new special purpose becomes known (for instance, the requirements for planning a flight in a new jurisdiction), that information can be added in a new field of `FlightPlan` named for the special purpose.

Perhaps the change with the largest test implementation impact is that the response to a user's flight planning attempt is limited to the information that would necessarily be provided to the operator.  This means that the operational intent ID is removed from this response, as USSs would not necessarily provide the operational intent ID to the operator since they don't necessarily need to have it in many situations -- uss_qualifier will need to infer the operational intent that was created (if any) in response to this request by examining the airspace before and after the completed request.

Two separate scopes are used to differentiate the test director acting as a test director (can interrogate the status and version of the system, request area clearing, etc) and the test director acting as a user planning flights.

api_name and api_version are added so that uss_qualifier can determine whether a provided interface implementation will work -- this anticipates updates to the API that may not be implemented immediately by USSs.  So, for instance, if the most recent API version were 1.1.3 and a USS provided an implementation of the 1.0.2 API, some steps of uss_qualifier may be able to proceed while other steps may require the features added in 1.1.0 of the API.

Special-purpose data structures are moved into their own YAML files $ref'd into the primary interface YAML for clarity.