### PR TITLE
Add GET /status operationId

### DIFF
--- a/flight_planning/v1/flight_planning.yaml
+++ b/flight_planning/v1/flight_planning.yaml
@@ -289,6 +289,7 @@ paths:
           description: The USS automated testing interface is not available.
       summary: Status of the USS automated testing interface
       description: Get the status of the USS automated testing interface.
+      operationId: GetStatus
 
   /clear_area_requests:
     post:


### PR DESCRIPTION
Although operationIds are not required, code generation benefits when all operations have an explicit ID.  The ID for GET /status in the flight_planning interface was accidentally omitted.  This PR fixes that problem.