### PR TITLE
[rid injection] Add MSL altitude

### DIFF
--- a/rid/v1/commons.yaml
+++ b/rid/v1/commons.yaml
@@ -9,6 +9,24 @@ components:
       description: An altitude, in meters, above the WGS84 ellipsoid.
       type: number
       example: 1321.2
+    AltitudeReference:
+      type: string
+      enum:
+        - W84
+        - EGM96
+        - EGM2008
+        - Other
+    MSLAltitude:
+      type: object
+      properties:
+        meters:
+          description: Height, in meters, above a mean sea level datum.
+          type: number
+          format: float
+          example: 103
+          default: 0
+        reference_datum:
+          $ref: '#/components/schemas/AltitudeReference'
     Latitude:
       format: double
       description: Degrees of latitude north of the equator, with reference to the

--- a/rid/v1/observation.yaml
+++ b/rid/v1/observation.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Remote ID Display Data Observation
-  version: 0.0.2
+  version: 0.1.0
   description: >-
     This interface is implemented by every Display Provider wishing to be tested by the automated testing framework.
     The automated testing suite calls this interface to obtain current remote ID information from the perspective of the Display Provider.

--- a/rid/v1/observation.yaml
+++ b/rid/v1/observation.yaml
@@ -187,6 +187,8 @@ components:
           $ref: 'commons.yaml#/components/schemas/Longitude'
         alt:
           $ref: 'commons.yaml#/components/schemas/Altitude'
+        msl_alt:
+          $ref: 'commons.yaml#/components/schemas/MSLAltitude'
         height:
           $ref: 'commons.yaml#/components/schemas/RIDHeight'
     Path:


### PR DESCRIPTION
The U-space regulation requires the network identification service to allow for the authorised users to receive messages with the altitude above mean sea level of the UAS.  In the InterUSS testing framework, this is equivalent to saying that RID observers must be provided with altitude above mean sea level.  Although the WGS84 ellipsoid is one approximation of mean sea level, the general expectation is that (and the Guidance Material indicates) the MSL altitude be provided above the EGM96 or EGM2008 geoid.

This PR adds the ability for RID observers to optionally specify MSL altitude that fulfills this requirement.  The approach is likely less than ideal as our current Altitude structure is not flexible enough to adapt without breaking backwards compatibility -- a more ideal approach would likely be something closer to the altitude structure in #16.  But, I think this approach will work fine, and it has the strong benefit of maintaining backwards compatibility.