### PR TITLE
Add access token requirements

### DIFF
--- a/flight_planning/v1/flight_planning.yaml
+++ b/flight_planning/v1/flight_planning.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Flight Planning Automated Testing Interface
-  version: 0.4.0
+  version: 0.4.1
   description: >-
     This interface is implemented by a USS wishing to participate in automated tests involving attempts to plan flights.
     
@@ -34,6 +34,20 @@ components:
               flight plan.
       description: |-
         Authorization from, or on behalf of, an authorization authority, augmenting standard strategic conflict detection or other similar authorization for the purpose of automated testing.
+        
+        This authority will issue access tokens that are JSON Web Tokens as defined in RFC 7519, using the `RS256` algorithm for the signature, and publish to all providers the public key for verifying that signature.
+
+        The following fields must be included in the JWT claim for access tokens issued by this authority:
+
+        * `exp`, with a time no further than 1 hour in the future.
+
+        * `sub`, with unique ID of the client requesting the access token.
+
+        * `scope`, with a string composed of a space-separated list of strings indicating the scopes granted, per RFC 6749.
+
+        * `aud`, with the fully qualified domain name of the URL the access token will be used to access.  For example, if a USS were querying the endpoint at https://uss.example.com:8888/flight_planning/v1/flight_plans/db41f454-b255-470e-98d6-4c5096a295a1, the access token included in the request should specify `"aud": "uss.example.com"`.
+
+        Clients must provide these access tokens in an `Authorization` header in the form `Bearer <token>` in accordance with RFC 6750.
 
   schemas:
     FlightPlanID:

--- a/geo-awareness/v1/geo-awareness.yaml
+++ b/geo-awareness/v1/geo-awareness.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Geo-Awareness Automated Test Interfaces
-  version: 0.2.0
+  version: 0.2.1
   license:
     name: Apache License v2.0
     url: https://github.com/interuss/dss/blob/master/LICENSE
@@ -25,6 +25,20 @@ components:
               Client may instruct the USS under test to load Geozone data and may read Geo-Awareness information.
       description: |-
         Authorization from, or on behalf of, an authorization authority, augmenting standard Geo-Awareness authorization for the purpose of automated testing.
+
+        This authority will issue access tokens that are JSON Web Tokens as defined in RFC 7519, using the `RS256` algorithm for the signature, and publish to all providers the public key for verifying that signature.
+
+        The following fields must be included in the JWT claim for access tokens issued by this authority:
+
+        * `exp`, with a time no further than 1 hour in the future.
+
+        * `sub`, with unique ID of the client requesting the access token.
+
+        * `scope`, with a string composed of a space-separated list of strings indicating the scopes granted, per RFC 6749.
+
+        * `aud`, with the fully qualified domain name of the URL the access token will be used to access.  For example, if a USS were querying the endpoint at https://uss.example.com:8888/geoawareness/geozone_sources/133bd471-ba61-4f1f-ae51-11570c2b3bb9, the access token included in the request should specify `"aud": "uss.example.com"`.
+
+        Clients must provide these access tokens in an `Authorization` header in the form `Bearer <token>` in accordance with RFC 6750.
 
   schemas:
     UUIDv4Format:

--- a/geospatial_map/v1/geospatial_map.yaml
+++ b/geospatial_map/v1/geospatial_map.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Geospatial Map Provider Automated Testing Interface
-  version: 0.2.0
+  version: 0.2.1
   license:
     name: Apache License v2.0
     url: https://github.com/interuss/automated_testing_interfaces/blob/main/LICENSE.md
@@ -35,6 +35,20 @@ components:
               Client may read information from the USS's geospatial map (acting as a user of the USS's geospatial map).
       description: |-
         Authorization from, or on behalf of, an authorization authority, augmenting standard Geo-Awareness authorization for the purpose of automated testing.
+
+        This authority will issue access tokens that are JSON Web Tokens as defined in RFC 7519, using the `RS256` algorithm for the signature, and publish to all providers the public key for verifying that signature.
+
+        The following fields must be included in the JWT claim for access tokens issued by this authority:
+
+        * `exp`, with a time no further than 1 hour in the future.
+
+        * `sub`, with unique ID of the client requesting the access token.
+
+        * `scope`, with a string composed of a space-separated list of strings indicating the scopes granted, per RFC 6749.
+
+        * `aud`, with the fully qualified domain name of the URL the access token will be used to access.  For example, if a USS were querying the endpoint at https://uss.example.com:8888/geospatial_map/geospatial_data_sources/32ef0162-30c4-4e56-9ce0-b204155ef93d, the access token included in the request should specify `"aud": "uss.example.com"`.
+
+        Clients must provide these access tokens in an `Authorization` header in the form `Bearer <token>` in accordance with RFC 6750.
 
   schemas:
     UUIDv4Format:

--- a/rid/v1/injection.yaml
+++ b/rid/v1/injection.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Remote ID Test Data Injection
-  version: 0.1.0
+  version: 0.1.1
   description: >-
     This interface is implemented by every Service Provider wishing to be tested by the automated testing framework.
     The automated testing suite calls this interface to inject flight-related test data into the Service Provider system under test.
@@ -597,6 +597,20 @@ components:
       type: oauth2
       description: |-
         Authorization from, or on behalf of, an authorization authority, augmenting standard remote ID authorization for the purpose of automated testing.
+
+        This authority will issue access tokens that are JSON Web Tokens as defined in RFC 7519, using the `RS256` algorithm for the signature, and publish to all providers the public key for verifying that signature.
+
+        The following fields must be included in the JWT claim for access tokens issued by this authority:
+
+        * `exp`, with a time no further than 1 hour in the future.
+
+        * `sub`, with unique ID of the client requesting the access token.
+
+        * `scope`, with a string composed of a space-separated list of strings indicating the scopes granted, per RFC 6749.
+
+        * `aud`, with the fully qualified domain name of the URL the access token will be used to access.  For example, if a USS were querying the endpoint at https://uss.example.com:8888/rid_injection/tests/283ac627-5d68-4cfe-805b-dc0bec7d8fdc/v5, the access token included in the request should specify `"aud": "uss.example.com"`.
+
+        Clients must provide these access tokens in an `Authorization` header in the form `Bearer <token>` in accordance with RFC 6750.
 
 security:
   - TestAuth:

--- a/rid/v1/observation.yaml
+++ b/rid/v1/observation.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Remote ID Display Data Observation
-  version: 0.1.0
+  version: 0.1.1
   description: >-
     This interface is implemented by every Display Provider wishing to be tested by the automated testing framework.
     The automated testing suite calls this interface to obtain current remote ID information from the perspective of the Display Provider.
@@ -213,6 +213,19 @@ components:
       description: |-
         Authorization from, or on behalf of, an authorization authority, matching standard remote ID authorization.
 
+        This authority will issue access tokens that are JSON Web Tokens as defined in RFC 7519, using the `RS256` algorithm for the signature, and publish to all providers the public key for verifying that signature.
+
+        The following fields must be included in the JWT claim for access tokens issued by this authority:
+
+        * `exp`, with a time no further than 1 hour in the future.
+
+        * `sub`, with unique ID of the client requesting the access token.
+
+        * `scope`, with a string composed of a space-separated list of strings indicating the scopes granted, per RFC 6749.
+
+        * `aud`, with the fully qualified domain name of the URL the access token will be used to access.  For example, if a USS were querying the endpoint at https://uss.example.com:8888/rid_observation/display_data/a1711ef3-2373-4ea2-bbbc-f92f57285406, the access token included in the request should specify `"aud": "uss.example.com"`.
+
+        Clients must provide these access tokens in an `Authorization` header in the form `Bearer <token>` in accordance with RFC 6750.
 security:
   - RIDAuth:
       - dss.read.identification_service_areas

--- a/scd/v1/scd.yaml
+++ b/scd/v1/scd.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Strategic Coordination Test Data Injection
-  version: 0.2.0
+  version: 0.2.1
   description: >-
     This interface is implemented by every USS wishing to enable the automated testing framework to interact with the
     USS as a user planning flights.  This interaction capability is required by some automated tests.
@@ -18,6 +18,20 @@ components:
               Client may inject test data into a USS for the purpose of conducting automated tests.
       description: |-
         Authorization from, or on behalf of, an authorization authority, augmenting standard scd authorization for the purpose of automated testing.
+
+        This authority will issue access tokens that are JSON Web Tokens as defined in RFC 7519, using the `RS256` algorithm for the signature, and publish to all providers the public key for verifying that signature.
+
+        The following fields must be included in the JWT claim for access tokens issued by this authority:
+
+        * `exp`, with a time no further than 1 hour in the future.
+
+        * `sub`, with unique ID of the client requesting the access token.
+
+        * `scope`, with a string composed of a space-separated list of strings indicating the scopes granted, per RFC 6749.
+
+        * `aud`, with the fully qualified domain name of the URL the access token will be used to access.  For example, if a USS were querying the endpoint at https://uss.example.com:8888/scd_injection/v1/flights/5a312fa5-4f63-444c-8919-21d7593a51bf, the access token included in the request should specify `"aud": "uss.example.com"`.
+
+        Clients must provide these access tokens in an `Authorization` header in the form `Bearer <token>` in accordance with RFC 6750.
 
   schemas:
     StatusResponse:

--- a/versioning/versioning.yaml
+++ b/versioning/versioning.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Versioning Automated Testing Interface
-  version: 0.1.0
+  version: 0.1.1
   description: >-
     This interface is implemented by a USS wishing to provide information about the version(s) of its software to
     authorized recipients in an automated fashion.
@@ -21,6 +21,20 @@ components:
               Client may read the version(s) of the USS's software deployed in this environment.
       description: |-
         Authorization from, or on behalf of, an authorization authority, for the purpose of facilitating automated testing.
+
+        This authority will issue access tokens that are JSON Web Tokens as defined in RFC 7519, using the `RS256` algorithm for the signature, and publish to all providers the public key for verifying that signature.
+
+        The following fields must be included in the JWT claim for access tokens issued by this authority:
+
+        * `exp`, with a time no further than 1 hour in the future.
+
+        * `sub`, with unique ID of the client requesting the access token.
+
+        * `scope`, with a string composed of a space-separated list of strings indicating the scopes granted, per RFC 6749.
+
+        * `aud`, with the fully qualified domain name of the URL the access token will be used to access.  For example, if a USS were querying the endpoint at https://uss.example.com:8888/eu/versions/uspace, the access token included in the request should specify `"aud": "uss.example.com"`.
+
+        Clients must provide these access tokens in an `Authorization` header in the form `Bearer <token>` in accordance with RFC 6750.
 
   schemas:
     SystemBoundaryIdentifier:


### PR DESCRIPTION
Currently, all APIs in this repo generally assume the same kind of federated ecosystem environment as the ASTM standards they are generally intended to test.  One key requirement for operating in such an environment is to prevent access token reuse.  The ASTM standards specify how this is accomplished, but the APIs in this repo currently do not, and as a result, they do not prevent token reuse when only the API is followed as-documented.  This PR fixes this issue by specifying more access token conditions, especially including the use of the `aud` claim to prevent token reuse.

This change should have no impact on existing implementations that already followed the previously-undocumented ASTM-style intent (such as everything in the [`monitoring` repo](https://github.com/interuss/monitoring)), and merely require the addition of fundamentally necessary security to others.