### PR TITLE
[openapi] single backslash escape for UUID Regex

### DIFF
--- a/flight_planning/v1/flight_planning.yaml
+++ b/flight_planning/v1/flight_planning.yaml
@@ -58,7 +58,7 @@ components:
       type: string
       format: uuid
       pattern: >-
-        ^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$
+        ^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-4[0-9a-fA-F]{3}\-[8-b][0-9a-fA-F]{3}\-[0-9a-fA-F]{12}$
       example: 03e5572a-f733-49af-bc14-8a18bd53ee39
 
     StatusResponse:

--- a/geo-awareness/v1/geo-awareness.yaml
+++ b/geo-awareness/v1/geo-awareness.yaml
@@ -49,7 +49,7 @@ components:
       type: string
       format: uuid
       pattern: >-
-        ^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$
+        ^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-4[0-9a-fA-F]{3}\-[8-b][0-9a-fA-F]{3}\-[0-9a-fA-F]{12}$
       example: 03e5572a-f733-49af-bc14-8a18bd53ee39
 
     StatusResponse:

--- a/geospatial_map/v1/geospatial_map.yaml
+++ b/geospatial_map/v1/geospatial_map.yaml
@@ -59,7 +59,7 @@ components:
       type: string
       format: uuid
       pattern: >-
-        ^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$
+        ^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-4[0-9a-fA-F]{3}\-[8-b][0-9a-fA-F]{3}\-[0-9a-fA-F]{12}$
       example: 03e5572a-f733-49af-bc14-8a18bd53ee39
 
     StatusResponse:

--- a/scd/v1/scd.yaml
+++ b/scd/v1/scd.yaml
@@ -61,7 +61,7 @@ components:
       type: string
       format: uuid
       pattern: >-
-        ^[0-9a-fA-F]{8}\\-[0-9a-fA-F]{4}\\-4[0-9a-fA-F]{3}\\-[8-b][0-9a-fA-F]{3}\\-[0-9a-fA-F]{12}$
+        ^[0-9a-fA-F]{8}\-[0-9a-fA-F]{4}\-4[0-9a-fA-F]{3}\-[8-b][0-9a-fA-F]{3}\-[0-9a-fA-F]{12}$
       example: 03e5572a-f733-49af-bc14-8a18bd53ee39
     EntityID:
       description: >-


### PR DESCRIPTION
The regular expression specified in the `pattern` for various UUID fields uses two backslashes for escaping the dashes (`\\-`) when it should only use one (`\-`), similarly to how it is done on the [F3548-21 branch of the astum-utm protocol ](https://github.com/astm-utm/Protocol/blob/d26d3222b9816a5bc90d00287c9746c4255f8f0d/utm.yaml#L128).

Some participants rely on these definitions to validate payloads received from the APIs, and run into problems.