### PR TITLE
[openapi] move or add fields from injection.yaml to commons.yaml

### DIFF
--- a/rid/v1/commons.yaml
+++ b/rid/v1/commons.yaml
@@ -263,6 +263,7 @@ components:
         - Rocket
         - TetheredPoweredAircraft
         - GroundObstacle
+        - VTOL
         - Other
       type: string
       default: NotDeclared

--- a/rid/v1/commons.yaml
+++ b/rid/v1/commons.yaml
@@ -109,6 +109,11 @@ components:
       exclusiveMinimum: false
       type: number
       example: 1.9
+    VerticalSpeed:
+      format: float
+      description: Speed up (vertically) WGS84-HAE, m/s
+      type: number
+      example: 0.2
     RIDTrack:
       format: float
       description: Direction of flight expressed as a "True North-based" ground
@@ -119,3 +124,168 @@ components:
       minimum: 0
       exclusiveMinimum: false
       type: number
+    HorizontalAccuracy:
+      description: |-
+        This is based on ADS-B NACp (plus the one extra increment).
+
+        `HAUnknown`: Unknown horizontal accuracy
+
+        `HA10NMPlus`: > 10NM (18.52km)
+
+        `HA10NM`: < 10NM (18.52km)
+
+        `HA4NM`: < 4NM (7.408km)
+
+        `HA2NM`: < 2NM (3.704km)
+
+        `HA1NM`: < 1NM (1852m)
+
+        `HA05NM`: < 0.5NM (926m)
+
+        `HA03NM`: < 0.3NM (555.6m)
+
+        `HA01NM`: < 0.1NM (185.2m)
+
+        `HA005NM`: < 0.05NM (92.6m)
+
+        `HA30m`: < 30m
+
+        `HA10m`: < 10m
+
+        `HA3m`: < 3m
+
+        `HA1m`: < 1m
+      enum:
+        - HAUnknown
+        - HA10NMPlus
+        - HA10NM
+        - HA4NM
+        - HA2NM
+        - HA1NM
+        - HA05NM
+        - HA03NM
+        - HA01NM
+        - HA005NM
+        - HA30m
+        - HA10m
+        - HA3m
+        - HA1m
+      type: string
+      default: HAUnknown
+    VerticalAccuracy:
+      description: |-
+        This is based on ADS-B Geodetic Vertical Accuracy (GVA) (plus the three extra increments)
+
+        `VAUnknown`: Unknown vertical accuracy
+
+        `VA150mPlus`: > 150m
+
+        `VA150m`: < 150m
+
+        `VA45m`: < 45m
+
+        `VA25m`: < 25m
+
+        `VA10m`: < 10m
+
+        `VA3m`: < 3m
+
+        `VA1m`: < 1m
+      enum:
+        - VAUnknown
+        - VA150mPlus
+        - VA150m
+        - VA45m
+        - VA25m
+        - VA10m
+        - VA3m
+        - VA1m
+      type: string
+      default: VAUnknown
+    SpeedAccuracy:
+      description: |-
+        This is the same enumeration scale and values from ADS-B NACv.
+
+        `SAUnknown`: Unknown speed accuracy
+
+        `SA10mpsPlus`: > 10 m/s
+
+        `SA10mps`: < 10 m/s
+
+        `SA3mps`: < 3 m/s
+
+        `SA1mps`: < 1 m/s
+
+        `SA03mps`: < 0.3 m/s
+      enum:
+        - SAUnknown
+        - SA10mpsPlus
+        - SA10mps
+        - SA3mps
+        - SA1mps
+        - SA03mps
+      type: string
+    TimestampAccuracy:
+      format: float
+      description: 'Declaration of timestamp accuracy, which is the largest difference
+        between Timestamp and true time of applicability for any of the following
+        fields: Latitude, Longitude, Geodetic Altitude, Pressure Altitude of Position,
+        Height. to determine time of applicability of the location data provided.  Expressed
+        in seconds, precise to 1/10ths of seconds. The accuracy reflects the 95%
+        uncertainty bound value for the timestamp.'
+      minimum: 0
+      exclusiveMinimum: false
+      type: number
+    UAType:
+      description: |-
+        The UA Type can help infer performance, speed, and duration of flights, for example, a
+        "fixed wing" can generally fly in a forward direction only (as compared to a multi-rotor).
+        This can also help differentiate aircraft types without sharing operationally sensitive
+        information like the make and model of a particular aircraft. Make and model are
+        anticipated to become available during the Registration ID lookup process. UAS Type is also
+        useful for correlating visual observation with data received. The types were formulated
+        based on unique flight characteristics.
+
+        `HybridLift` is a fixed wing aircraft that can take off vertically.  `Helicopter` includes multirotor.
+      enum:
+        - NotDeclared
+        - Aeroplane
+        - Helicopter
+        - Gyroplane
+        - HybridLift
+        - Ornithopter
+        - Glider
+        - Kite
+        - FreeBalloon
+        - CaptiveBalloon
+        - Airship
+        - FreeFallOrParachute
+        - Rocket
+        - TetheredPoweredAircraft
+        - GroundObstacle
+        - Other
+      type: string
+      default: NotDeclared
+    UAClassificationEU:
+      type: object
+      properties:
+        category:
+          type: string
+          enum:
+            - EUCategoryUndefined
+            - Open
+            - Specific
+            - Certified
+          default: EUCategoryUndefined
+        class:
+          type: string
+          enum:
+            - EUClassUndefined
+            - Class0
+            - Class1
+            - Class2
+            - Class3
+            - Class4
+            - Class5
+            - Class6
+          default: EUClassUndefined

--- a/rid/v1/commons.yaml
+++ b/rid/v1/commons.yaml
@@ -126,7 +126,7 @@ components:
       type: number
     HorizontalAccuracy:
       description: |-
-        This is based on ADS-B NACp (plus the one extra increment).
+        This is the NACp enumeration from ADS-B, plus 1m for a more complete range for UAs.
 
         `HAUnknown`: Unknown horizontal accuracy
 
@@ -171,10 +171,9 @@ components:
         - HA3m
         - HA1m
       type: string
-      default: HAUnknown
     VerticalAccuracy:
       description: |-
-        This is based on ADS-B Geodetic Vertical Accuracy (GVA) (plus the three extra increments)
+        This is the GVA enumeration from ADS-B, plus some finer values for UAs.
 
         `VAUnknown`: Unknown vertical accuracy
 
@@ -201,7 +200,6 @@ components:
         - VA3m
         - VA1m
       type: string
-      default: VAUnknown
     SpeedAccuracy:
       description: |-
         This is the same enumeration scale and values from ADS-B NACv.
@@ -236,23 +234,17 @@ components:
       minimum: 0
       exclusiveMinimum: false
       type: number
-    UAType:
+    RIDAircraftType:
       description: |-
-        The UA Type can help infer performance, speed, and duration of flights, for example, a
-        "fixed wing" can generally fly in a forward direction only (as compared to a multi-rotor).
-        This can also help differentiate aircraft types without sharing operationally sensitive
-        information like the make and model of a particular aircraft. Make and model are
-        anticipated to become available during the Registration ID lookup process. UAS Type is also
-        useful for correlating visual observation with data received. The types were formulated
-        based on unique flight characteristics.
+        Type of aircraft for the purposes of remote ID.
 
-        `HybridLift` is a fixed wing aircraft that can take off vertically.  `Helicopter` includes multirotor.
+        `VTOL` is a fixed wing aircraft that can take off vertically.  `Helicopter` includes multirotor.
       enum:
         - NotDeclared
         - Aeroplane
         - Helicopter
         - Gyroplane
-        - HybridLift
+        - VTOL
         - Ornithopter
         - Glider
         - Kite
@@ -263,10 +255,9 @@ components:
         - Rocket
         - TetheredPoweredAircraft
         - GroundObstacle
-        - VTOL
         - Other
+        - HybridLift
       type: string
-      default: NotDeclared
     UAClassificationEU:
       type: object
       properties:

--- a/rid/v1/injection.yaml
+++ b/rid/v1/injection.yaml
@@ -301,30 +301,6 @@ components:
             the "Operation Area End" data from the common data dictionary when group
             operation area is specified by point-radius.
           type: string
-    RIDAircraftType:
-      description: |-
-        Type of aircraft for the purposes of remote ID.
-
-        `VTOL` is a fixed wing aircraft that can take off vertically.  `Helicopter` includes multirotor.
-      enum:
-        - NotDeclared
-        - Aeroplane
-        - Helicopter
-        - Gyroplane
-        - VTOL
-        - Ornithopter
-        - Glider
-        - Kite
-        - FreeBalloon
-        - CaptiveBalloon
-        - Airship
-        - FreeFallOrParachute
-        - Rocket
-        - TetheredPoweredAircraft
-        - GroundObstacle
-        - Other
-        - HybridLift
-      type: string
     SpecificSessionID:
       description: |-
         A unique 20 byte ID intended to identify a specific flight (session) while providing a

--- a/rid/v1/injection.yaml
+++ b/rid/v1/injection.yaml
@@ -193,29 +193,6 @@ components:
         - VA3m
         - VA1m
       type: string
-    SpeedAccuracy:
-      description: |-
-        This is the same enumeration scale and values from ADS-B NACv.
-
-        `SAUnknown`: Unknown speed accuracy
-
-        `SA10mpsPlus`: > 10 m/s
-
-        `SA10mps`: < 10 m/s
-
-        `SA3mps`: < 3 m/s
-
-        `SA1mps`: < 1 m/s
-
-        `SA03mps`: < 0.3 m/s
-      enum:
-        - SAUnknown
-        - SA10mpsPlus
-        - SA10mps
-        - SA3mps
-        - SA1mps
-        - SA03mps
-      type: string
     RIDAircraftPosition:
       description: Position of an aircraft as reported for remote ID purposes.
       required:
@@ -303,7 +280,7 @@ components:
             Union".  If no other classification field is specified, the Classification Type
             is "Undeclared".
           anyOf:
-            - $ref: '#/components/schemas/UAClassificationEU'
+            - $ref: 'commons.yaml#/components/schemas/UAClassificationEU'
     RIDRecentAircraftPosition:
       description: ""
       required:
@@ -341,16 +318,7 @@ components:
             3339 format, per OpenAPI specification.
           type: string
         timestamp_accuracy:
-          format: float
-          description: 'Declaration of timestamp accuracy, which is the largest difference
-            between Timestamp and true time of applicability for any of the following
-            fields: Latitude, Longitude, Geodetic Altitude, Pressure Altitude of Position,
-            Height. to determine time of applicability of the location data provided.  Expressed
-            in seconds, precise to 1/10ths of seconds. The accuracy reflects the 95%
-            uncertainty bound value for the timestamp.'
-          minimum: 0
-          exclusiveMinimum: false
-          type: number
+          $ref: 'commons.yaml#/components/schemas/TimestampAccuracy'
         operational_status:
           $ref: 'commons.yaml#/components/schemas/RIDOperationalStatus'
         position:
@@ -361,13 +329,10 @@ components:
           $ref: 'commons.yaml#/components/schemas/RIDSpeed'
         speed_accuracy:
           anyOf:
-            - $ref: '#/components/schemas/SpeedAccuracy'
+            - $ref: 'commons.yaml#/components/schemas/SpeedAccuracy'
           description: Accuracy of horizontal ground speed.
         vertical_speed:
-          format: float
-          description: Speed up (vertically) WGS84-HAE, m/s.
-          type: number
-          example: 0.2
+          $ref: 'commons.yaml#/components/schemas/VerticalSpeed'
         height:
           $ref: 'commons.yaml#/components/schemas/RIDHeight'
         group_radius:
@@ -436,29 +401,6 @@ components:
         - Other
         - HybridLift
       type: string
-    UAClassificationEU:
-      type: object
-      properties:
-        category:
-          type: string
-          enum:
-            - EUCategoryUndefined
-            - Open
-            - Specific
-            - Certified
-          default: EUCategoryUndefined
-        class:
-          type: string
-          enum:
-            - EUClassUndefined
-            - Class0
-            - Class1
-            - Class2
-            - Class3
-            - Class4
-            - Class5
-            - Class6
-          default: EUClassUndefined
     SpecificSessionID:
       description: |-
         A unique 20 byte ID intended to identify a specific flight (session) while providing a

--- a/rid/v1/injection.yaml
+++ b/rid/v1/injection.yaml
@@ -117,82 +117,6 @@ components:
           description: Authentication data in form specified by `format`.
           type: string
           default: ''
-    HorizontalAccuracy:
-      description: |-
-        This is the NACp enumeration from ADS-B, plus 1m for a more complete range for UAs.
-
-        `HAUnknown`: Unknown horizontal accuracy
-
-        `HA10NMPlus`: > 10NM (18.52km)
-
-        `HA10NM`: < 10NM (18.52km)
-
-        `HA4NM`: < 4NM (7.408km)
-
-        `HA2NM`: < 2NM (3.704km)
-
-        `HA1NM`: < 1NM (1852m)
-
-        `HA05NM`: < 0.5NM (926m)
-
-        `HA03NM`: < 0.3NM (555.6m)
-
-        `HA01NM`: < 0.1NM (185.2m)
-
-        `HA005NM`: < 0.05NM (92.6m)
-
-        `HA30m`: < 30m
-
-        `HA10m`: < 10m
-
-        `HA3m`: < 3m
-
-        `HA1m`: < 1m
-      enum:
-        - HAUnknown
-        - HA10NMPlus
-        - HA10NM
-        - HA4NM
-        - HA2NM
-        - HA1NM
-        - HA05NM
-        - HA03NM
-        - HA01NM
-        - HA005NM
-        - HA30m
-        - HA10m
-        - HA3m
-        - HA1m
-      type: string
-    VerticalAccuracy:
-      description: |-
-        This is the GVA enumeration from ADS-B, plus some finer values for UAs.
-
-        `VAUnknown`: Unknown vertical accuracy
-
-        `VA150mPlus`: > 150m
-
-        `VA150m`: < 150m
-
-        `VA45m`: < 45m
-
-        `VA25m`: < 25m
-
-        `VA10m`: < 10m
-
-        `VA3m`: < 3m
-
-        `VA1m`: < 1m
-      enum:
-        - VAUnknown
-        - VA150mPlus
-        - VA150m
-        - VA45m
-        - VA25m
-        - VA10m
-        - VA3m
-        - VA1m
-      type: string
     RIDAircraftPosition:
       description: Position of an aircraft as reported for remote ID purposes.
       required:
@@ -211,13 +135,13 @@ components:
           $ref: 'commons.yaml#/components/schemas/RIDHeight'
         accuracy_h:
           anyOf:
-            - $ref: '#/components/schemas/HorizontalAccuracy'
+            - $ref: 'commons.yaml#/components/schemas/HorizontalAccuracy'
           description: Horizontal error that is likely to be present in this reported
             position.  Required when `extrapolated` field is true and always in the
             entry for the current state.
         accuracy_v:
           anyOf:
-            - $ref: '#/components/schemas/VerticalAccuracy'
+            - $ref: 'commons.yaml#/components/schemas/VerticalAccuracy'
           description: Vertical error that is likely to be present in this reported
             position.  Required when `extrapolated` field is true and always in the
             entry for the current state.


### PR DESCRIPTION
To prepare for some changes to the injection and observation API that is required for https://github.com/interuss/monitoring/issues/754, this PR moves and adds some object definitions to commons.yaml, so they may be referenced from both injection.yaml and observation.yaml in subsequent PRs.

Definitions and behaviors should still be equivalent to before.