### PR TITLE
[rid/injection] make fields optional on state and position

### DIFF
--- a/rid/v1/injection.yaml
+++ b/rid/v1/injection.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Remote ID Test Data Injection
-  version: 0.3.0
+  version: 0.4.0
   description: >-
     This interface is provided by every Service Provider wishing to be tested by the automated testing framework.
     The automated testing suite calls this interface to inject flight-related test data into the Service Provider system under test.
@@ -118,11 +118,17 @@ components:
           type: string
           default: ''
     RIDAircraftPosition:
-      description: Position of an aircraft as reported for remote ID purposes.
-      required:
+      description: "
+      Position of an aircraft as reported for remote ID purposes.
+      
+      The following fields are required for a successful injection, but are not included in the 'required' field
+      to allow the uss_qualifier to check SP behavior in situations where a networked UAS would not provide the necessary data
+      to participate in Network Remote ID:
+      
         - lat
         - lng
         - alt
+      "
       type: object
       properties:
         lat:
@@ -220,8 +226,13 @@ components:
         position:
           $ref: '#/components/schemas/RIDAircraftPosition'
     RIDAircraftState:
-      description: State of an aircraft for the purposes of remote ID.
-      required:
+      description: "
+      State of an aircraft for the purposes of remote ID.
+      
+      The following fields are required for a successful injection, but are not included in the 'required' field
+      to allow the uss_qualifier to check SP behavior in situations where a networked UAS would not provide the necessary data
+      to participate in Network Remote ID:
+      
         - timestamp
         - timestamp_accuracy
         - accuracy_h
@@ -231,6 +242,7 @@ components:
         - track
         - speed_accuracy
         - position
+      "
       type: object
       properties:
         timestamp:


### PR DESCRIPTION
NetRID requirement NET0030 states:

> The Net-RID Service Provider shall (NET0030) notify the operator of a Networked UAS if the UAS is not providing necessary data to participate in Network Remote ID.

In order to test this requirement, [uss_qualifier](https://github.com/interuss/monitoring/tree/main/monitoring/uss_qualifier) needs to be able to request from the injection API that an SP simulates such a flight, in order to verify that the operator would get a notification.

This PR proposes that implementations of the injection API would still require the now-optional fields for a _proper_ injection (that is, an injection that results in an actual flight being simulated); injection attempts that don't provide them would still result in a successful call. 

In the second case, no flight would be injected, but a notification is expected to be dispatched to the test operator, and this fact can be detected by `uss_qualifier` when using the `user_notification` API.