### PR TITLE
[rid/injection] Add user notifications endpoint

### DIFF
--- a/rid/README.md
+++ b/rid/README.md
@@ -7,20 +7,20 @@ the systems under test.
 To view these YAML files locally:
 
 ```shell script
-docker run -it --rm -p 8080:8080 \
-  -v $(pwd)/v1/observation.yaml:/usr/share/nginx/html/swagger.yaml \
-  -e PORT=8080 -e SPEC_URL=swagger.yaml redocly/redoc
+docker run -it --rm -p 8888:8888 \
+  -v $(pwd)/:/usr/share/nginx/html/api/ \
+  -e PORT=8888 -e SPEC_URL=./api/v1/observation.yaml redocly/redoc
 ```
 
 OR
 
 ```shell script
-docker run -it --rm -p 8080:8080 \
-  -v $(pwd)/v1/injection.yaml:/usr/share/nginx/html/swagger.yaml \
-  -e PORT=8080 -e SPEC_URL=swagger.yaml redocly/redoc
+docker run -it --rm -p 8888:8888 \
+  -v $(pwd)/:/usr/share/nginx/html/api/ \
+  -e PORT=8888 -e SPEC_URL=./api/v1/injection.yaml redocly/redoc
 ```
 
-...then visit [http://localhost:8080/](http://localhost:8080/) in a browser.
+...then visit [http://localhost:8888/](http://localhost:8080/) in a browser.
 
 ## Architecture
 

--- a/rid/v1/injection.yaml
+++ b/rid/v1/injection.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Remote ID Test Data Injection
-  version: 0.4.0
+  version: 0.5.0
   description: >-
     This interface is provided by every Service Provider wishing to be tested by the automated testing framework.
     The automated testing suite calls this interface to inject flight-related test data into the Service Provider system under test.

--- a/rid/v1/injection.yaml
+++ b/rid/v1/injection.yaml
@@ -80,6 +80,53 @@ paths:
       security:
         - TestAuth:
             - rid.inject_test_data
+  /user_notifications:
+    get:
+      operationId: QueryUserNotifications
+      security:
+        - TestAuth:
+            - rid.inject_test_data
+      parameters:
+        - name: after
+          description: >-
+            Do not include any notifications observed before this time. 
+            The property 'observed_at' in UserNotification is to be used for comparison.
+          schema:
+            type: string
+            format: date-time
+          example: '2024-04-22T16:36:50.52Z'
+          in: query
+          required: true
+        - name: before
+          description: >-
+            Do not include any notifications observed after this time. 
+            This time must be after the time specified in 'after' parameter. 
+            If not provided, then the value defaults to now. 
+            The property 'observed_at' in UserNotification is to be used for comparison.
+          schema:
+            type: string
+            format: date-time
+          example: '2024-04-22T16:41:50.52Z'
+          in: query
+          required: false
+      responses:
+        '200':
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QueryUserNotificationsResponse'
+          description: User notifications sent retrieved successfully.
+        '400':
+          description: The request was missing 'after' query parameter, or the request was otherwise invalid.
+        '401':
+          description: Bearer access token was not provided in Authorization header, token could not be decoded, or token was invalid.
+        '403':
+          description: The access token was decoded successfully but did not include a scope appropriate to this endpoint.
+      summary: User notifications
+      description: >-
+        Returns the list of user notifications observed by the virtual user and applicable to the query parameters.  
+        The implementation of this endpoint requires that the user notifications be available for querying until the end of a test run.
+        The user notifications should be available to be queried within 5 seconds of observation by the virtual user.
 components:
   schemas:
     RIDFlightID:
@@ -444,6 +491,47 @@ components:
             The details of the flight.
             Follows the RIDFlightDetails schema from the ASTM remote ID standard.
           $ref: '#/components/schemas/RIDFlightDetails'
+    Time:
+      required:
+        - value
+        - format
+      type: object
+      properties:
+        value:
+          type: string
+          description: >-
+            RFC3339-formatted time/date string.  The time zone must be 'Z'.
+          format: date-time
+          example: '1985-04-12T23:20:50.52Z'
+        format:
+          type: string
+          enum:
+            - RFC3339
+    UserNotification:
+      type: object
+      description: Notification observed by virtual user.
+      required:
+        - observed_at
+      properties:
+        observed_at:
+          anyOf:
+            - $ref: '#/components/schemas/Time'
+          description: Time at which the virtual user observed the notification.
+        message:
+          description: Message presented to the user, description of notification, or other means of helping identify the nature of the notification, for the purpose of increased readability of test reports.
+          type: string
+    QueryUserNotificationsResponse:
+      type: object
+      description: Response object for query request for notifications observed by the virtual user.
+      required:
+        - user_notifications
+      properties:
+        user_notifications:
+          description: List of applicable observed user notifications.
+          type: array
+          items:
+            $ref: '#/components/schemas/UserNotification'
+
   securitySchemes:
     TestAuth:
       flows:


### PR DESCRIPTION
This PR adds a /user_notifications endpoint to the RID injection API that is compatible with the endpoint on the flight_planning API to enable testing of NET0030, NET0040, and potentially (probably not practically) NET0620.

We have the ability to [ask for observed user notifications in the flight_planning API](https://github.com/interuss/automated_testing_interfaces/blob/417797f42e8ebd7cc1b71e82ec0fee0fe1e972a1/flight_planning/v1/flight_planning.yaml#L492).  I think probably the best long-term solution would actually be to deprecate this entire RID injection API in favor of the flight_planning API [augmented with telemetry](https://github.com/interuss/automated_testing_interfaces/pull/16), but I don't think that's the best solution for MVP since we're pretty close to complete with the current injection API.  To work toward that end state, this PR semi-duplicates the flight_planning /user_notifications path in the RID injection API.