### PR TITLE
[flight_planning] Add RID-relevant information to flight planning interface

### DIFF
--- a/flight_planning/v1/flight_planning.yaml
+++ b/flight_planning/v1/flight_planning.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.2
 info:
   title: Flight Planning Automated Testing Interface
-  version: 0.6.0
+  version: 0.7.0
   description: >-
     This interface is provided by a USS wishing to participate in automated tests involving attempts to plan flights.
     
@@ -84,9 +84,9 @@ components:
           example: Flight Planning Automated Testing Interface
         api_version:
           description: |-
-            Indication of the API version implemented at this URL.  Must be "v0.6.0" when implementing this version of the API.
+            Indication of the API version implemented at this URL.  Must be "v0.7.0" when implementing this version of the API.
           type: string
-          example: v0.6.0
+          example: v0.7.0
 
     FlightPlan:
       description: >-
@@ -97,6 +97,10 @@ components:
       properties:
         basic_information:
           $ref: '#/components/schemas/BasicFlightPlanInformation'
+        uas:
+          $ref: './uas.yaml#/components/schemas/UASInformation'
+        operator:
+          $ref: './operator.yaml#/components/schemas/OperatorInformation'
         telemetry:
           description: |-
             Telemetry for the flight (see FlightTelemetry definition).
@@ -163,6 +167,28 @@ components:
           items:
             $ref: './geotemporal.yaml#/components/schemas/Volume4D'
           default: []
+        description:
+          description: Free-text field that enables the operator to describe the purpose of a flight, if so desired.
+          type: string
+          example: Medical supplies delivery operated by Example Drone Company
+          default: ''
+        utm_id:
+          description: A UTM-provided universally unique ID traceable to a
+            non-obfuscated ID that acts as a "session id" to protect exposure of
+            operationally sensitive information.
+          type: string
+          example: ae1fa066-6d68-4018-8274-af867966978e
+          default: ''
+        specific_session_id:
+          $ref: '#/components/schemas/SpecificSessionID'
+
+    SpecificSessionID:
+      description: |-
+        A unique ID intended to identify a specific flight (session) while providing a
+        greater level of privacy to the operator. Defined, for instance, in ASTM F3411.
+      type: string
+      example: 02-a1b2c3d4e5f60708
+      default: ''
 
     ExecutionStyle:
       type: string

--- a/flight_planning/v1/operator.yaml
+++ b/flight_planning/v1/operator.yaml
@@ -1,0 +1,49 @@
+info:
+  title: Definitions used in flight planning interface specific to the operator.
+components:
+  schemas:
+    OperatorInformation:
+      description: >-
+        Information about the operator that may be provided in flight planning scenarios.
+      type: object
+      properties:
+        registration_numbers:
+          description: Registration numbers for the remote pilot or operator.
+          type: array
+          items:
+            $ref: '#/components/schemas/OperatorRegistrationNumber'
+        location:
+          anyOf:
+            - $ref: './geotemporal.yaml#/components/schemas/LatLngPoint'
+          description: Location of operator.
+        altitude:
+          anyOf:
+            - $ref: './geotemporal.yaml#/components/schemas/Altitude'
+          description: Altitude of operator.
+
+    OperatorRegistrationNumber:
+      description: >-
+        Number provided by CAA or authorized representative for registering, licensing and/or identifying a remote
+        pilot or operator.
+      type: object
+      required:
+        - identifier
+      properties:
+        authority:
+          description: |-
+            Authority providing this registration number.  If authority represents a country, the ICAO nationality
+            mark is recommended.
+          type: string
+          example: N
+          default: ''
+        type:
+          description: |-
+            Type of license, registration, identifier, etc.
+          type: string
+          example: Part107License
+          default: ''
+        identifier:
+          description: |-
+            Authority-assigned number or identifier.
+          type: string
+          example: N.123456

--- a/flight_planning/v1/uas.yaml
+++ b/flight_planning/v1/uas.yaml
@@ -1,0 +1,109 @@
+info:
+  title: Definitions used in flight planning interface specific to the UAS.
+components:
+  schemas:
+    UASInformation:
+      description: >-
+        Information about a UAS that may be provided in flight planning scenarios.
+      type: object
+      properties:
+        aircraft_type:
+          anyOf:
+            - $ref: '#/components/schemas/UAType'
+          description: Aircraft type of the injected test flight.
+        serial_number:
+          description: This is generally expressed in the CTA-2063-A Serial Number format.
+          type: string
+          example: INTCJ123-4567-890
+          default: ''
+        registration_numbers:
+          description: >-
+            For each relevant authority with which this UAS is registered, the number/identifier assigned
+            to this UAS.
+          type: array
+          items:
+            $ref: '#/components/schemas/UASRegistrationNumber'
+          default: []
+        eu_classification:
+          description: EU classification of aircraft.
+          anyOf:
+            - $ref: '#/components/schemas/UAClassificationEU'
+
+    UASRegistrationNumber:
+      description: >-
+        Number provided by CAA or authorized representative for registering and/or identifying UAS.
+      type: object
+      required:
+        - identifier
+      properties:
+        authority:
+          description: |-
+            Authority providing this registration number.  If authority represents a country, the ICAO nationality
+            mark is recommended.
+          type: string
+          example: N
+          default: ''
+        type:
+          description: |-
+            Type of license, registration, identifier, etc.
+          type: string
+          example: Registration
+          default: ''
+        identifier:
+          description: |-
+            Authority-assigned number or identifier.
+          type: string
+          example: N.123456
+
+    UAType:
+      description: |-
+        The UA Type can help infer performance, speed, and duration of flights, for example, a
+        "fixed wing" can generally fly in a forward direction only (as compared to a multi-rotor).
+
+        `HybridLift` is a fixed wing aircraft that can take off vertically.  `Helicopter` includes multirotor.
+        
+        `VTOL` is equivalent to HybridLift.
+      enum:
+        - NotDeclared
+        - Aeroplane
+        - Helicopter
+        - Gyroplane
+        - VTOL
+        - HybridLift
+        - Ornithopter
+        - Glider
+        - Kite
+        - FreeBalloon
+        - CaptiveBalloon
+        - Airship
+        - FreeFallOrParachute
+        - Rocket
+        - TetheredPoweredAircraft
+        - GroundObstacle
+        - Other
+      type: string
+      default: NotDeclared
+
+    UAClassificationEU:
+      type: object
+      properties:
+        category:
+          type: string
+          enum:
+            - EUCategoryUndefined
+            - Open
+            - Specific
+            - Certified
+          default: EUCategoryUndefined
+        class:
+          type: string
+          enum:
+            - EUClassUndefined
+            - Class0
+            - Class1
+            - Class2
+            - Class3
+            - Class4
+            - Class5
+            - Class6
+          default: EUClassUndefined

--- a/flight_planning/v1/uas.yaml
+++ b/flight_planning/v1/uas.yaml
@@ -43,12 +43,6 @@ components:
           type: string
           example: N
           default: ''
-        type:
-          description: |-
-            Type of license, registration, identifier, etc.
-          type: string
-          example: Registration
-          default: ''
         identifier:
           description: |-
             Authority-assigned number or identifier.

--- a/flight_planning/v1/user_notification.yaml
+++ b/flight_planning/v1/user_notification.yaml
@@ -12,6 +12,9 @@ components:
           anyOf:
             - $ref: './geotemporal.yaml#/components/schemas/Time'
           description: Time at which the virtual user observed the notification.
+        message:
+          description: Message presented to the user, description of notification, or other means of helping identify the nature of the notification, for the purpose of increased readability of test reports.
+          type: string
         conflicts:
           description: >-
             Conflict status as indicated in the notification.            


### PR DESCRIPTION
Currently, we have two different interfaces for actuating flight-related activities on systems under test: the `rid` injection interface allows us to "inject" a flight for the purpose of remote ID testing, and the `flight_planning` interface allows us to originate a flight for other flight planning purposes.  This can be problematic for systems which perform multiple UTM functions in response to a single user interface, however, as they will need to implement two different interfaces and each interface may not specify a sufficient amount of information for the flight.

This PR attempts to move toward addressing this issue by adding RID-relevant information to the flight planning interface.  In the future, we can allow USSs to use either the `rid` injection interface or the `flight_planning` interface to "inject" RID flights (in the same way we support the deprecated `scd` interface alongside the `flight_planning` interface), which will then allow us to gracefully deprecate the `rid` injection interface entirely (the `rid` observation interface will remain relevant).

The information in this PR is intended to cover all the information in the `rid` injection interface, but not necessarily use the same format.  Instead, it attempts to capture the information that might be provided/necessary from a user of a USS's system if that USS were performing remote ID.  To this end, three groups of information are added to a `FlightPlan`:

* Identity of the flight (added directly to `BasicFlightPlanInformation`)
* Information about the UA/UAS (added as a new `uas` field with information defined in uas.yaml)
* Information about the remote pilot/operator (added as a new `operator` field with information defined in operator.yaml)

A small cleanup item is also added to user_notifications.